### PR TITLE
Change default port for flow-control to B

### DIFF
--- a/data-templates/device-config-wokwi.json
+++ b/data-templates/device-config-wokwi.json
@@ -4,14 +4,14 @@
   "location": "bumblebee",
   "peripherals": [
     {
-      "name": "flow-control-a",
+      "name": "flow-control",
       "type": "flow-control",
       "params": {
         "valve": {
-          "motor": "a"
+          "motor": "b"
         },
         "flow-meter": {
-          "pin": "A1"
+          "pin": "B1"
         }
       }
     }

--- a/data-templates/flow-control-mk5.json
+++ b/data-templates/flow-control-mk5.json
@@ -3,14 +3,14 @@
   "id": "DEVICE_ID",
   "peripherals": [
     {
-      "name": "flow-control-a",
+      "name": "flow-control",
       "type": "flow-control",
       "params": {
         "valve": {
-          "motor": "a"
+          "motor": "b"
         },
         "flow-meter": {
-          "pin": "A1"
+          "pin": "B1"
         }
       }
     }

--- a/data-templates/flow-control-mk6-fully-equipped.json
+++ b/data-templates/flow-control-mk6-fully-equipped.json
@@ -1,16 +1,16 @@
 {
-  "instance": "DEVICE_INSTANCE",
-  "id": "DEVICE_ID",
+  "instance": "test-mk6-xxx",
+  "location": "bumblebee",
   "peripherals": [
     {
-      "name": "flow-control-a",
+      "name": "flow-control",
       "type": "flow-control",
       "params": {
         "valve": {
-          "motor": "a"
+          "motor": "b"
         },
         "flow-meter": {
-          "pin": "A1"
+          "pin": "B1"
         }
       }
     },
@@ -18,7 +18,7 @@
       "name": "soil-temperature",
       "type": "environment:ds18b20",
       "params": {
-        "pin": "C3"
+        "pin": "A2"
       }
     },
     {
@@ -26,9 +26,10 @@
       "type": "environment:soil-moisture",
       "params": {
         "air": 3017,
-        "pin": "C4",
+        "pin": "A1",
         "water": 1105
       }
     }
-  ]
+  ],
+  "motorNSleepPin": "LOADEN"
 }

--- a/data-templates/flow-control-mk6-rev1-or-rev2.json
+++ b/data-templates/flow-control-mk6-rev1-or-rev2.json
@@ -3,14 +3,14 @@
   "id": "DEVICE_ID",
   "peripherals": [
     {
-      "name": "flow-control-a",
+      "name": "flow-control",
       "type": "flow-control",
       "params": {
         "valve": {
-          "motor": "a"
+          "motor": "b"
         },
         "flow-meter": {
-          "pin": "A1"
+          "pin": "B1"
         }
       }
     }

--- a/data-templates/flow-control-mk6.json
+++ b/data-templates/flow-control-mk6.json
@@ -3,14 +3,14 @@
   "id": "DEVICE_ID",
   "peripherals": [
     {
-      "name": "flow-control-a",
+      "name": "flow-control",
       "type": "flow-control",
       "params": {
         "valve": {
-          "motor": "a"
+          "motor": "b"
         },
         "flow-meter": {
-          "pin": "A1"
+          "pin": "B1"
         }
       }
     }

--- a/data-templates/test-mk6-rev3.json
+++ b/data-templates/test-mk6-rev3.json
@@ -3,14 +3,14 @@
   "location": "bumblebee",
   "peripherals": [
     {
-      "name": "flow-control-a",
+      "name": "flow-control",
       "type": "flow-control",
       "params": {
         "valve": {
-          "motor": "a"
+          "motor": "b"
         },
         "flow-meter": {
-          "pin": "A1"
+          "pin": "B1"
         }
       }
     }

--- a/data-templates/test-mk6.json
+++ b/data-templates/test-mk6.json
@@ -3,14 +3,14 @@
   "location": "bumblebee",
   "peripherals": [
     {
-      "name": "flow-control-a",
+      "name": "flow-control",
       "type": "flow-control",
       "params": {
         "valve": {
-          "motor": "a"
+          "motor": "b"
         },
         "flow-meter": {
-          "pin": "A1"
+          "pin": "B1"
         }
       }
     }


### PR DESCRIPTION
We want to use port A on the MK6 and MK5 for soil temperature and moisture metering.