### PR TITLE
Handle null values in JSON configuration

### DIFF
--- a/components/functions/functions/PlotController.hpp
+++ b/components/functions/functions/PlotController.hpp
@@ -49,6 +49,8 @@ public:
         : Named(name)
         , valve(valve)
         , flowMeter(flowMeter) {
+        LOGD("Creating plot controller '%s' with valve '%s' and flow meter '%s'",
+            name.c_str(), valve->name.c_str(), flowMeter->name.c_str());
     }
 
     void configure(const std::shared_ptr<PlotConfig>& config) override {

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -213,7 +213,7 @@ public:
     }
 
     void load(const JsonObject& json) override {
-        if (json[name].is<JsonVariant>()) {
+        if (!json[name].isNull() && json[name].is<JsonVariant>()) {
             value = json[name].as<T>();
             configured = true;
         } else {

--- a/components/peripherals/peripherals/flow_meter/FlowMeter.hpp
+++ b/components/peripherals/peripherals/flow_meter/FlowMeter.hpp
@@ -27,7 +27,8 @@ public:
     Property<milliseconds> measurementFrequency { this, "measurementFrequency", 1s };
 };
 
-class FlowMeter {
+class FlowMeter
+    : public Named {
 public:
     FlowMeter(
         const std::string& name,
@@ -35,7 +36,8 @@ public:
         const InternalPinPtr& pin,
         double qFactor,
         milliseconds measurementFrequency)
-        : qFactor(qFactor) {
+        : Named(name)
+        , qFactor(qFactor) {
 
         LOGI("Initializing flow meter on pin %s with Q = %.2f",
             pin->getName().c_str(), qFactor);

--- a/components/peripherals/peripherals/valve/Valve.hpp
+++ b/components/peripherals/peripherals/valve/Valve.hpp
@@ -29,7 +29,7 @@ using namespace farmhub::peripherals;
 namespace farmhub::peripherals::valve {
 
 class Valve
-    : Named
+    : public Named
     , public HasConfig<ValveConfig>
     , public HasShutdown {
 public:
@@ -159,7 +159,7 @@ public:
     }
 
     void configure(const std::list<ValveSchedule>& schedules, ValveState overrideState, time_point<system_clock> overrideUntil) {
-        LOGD("Configuring valve %s with %d schedules; override state %d until %lld",
+        LOGD("Configuring valve '%s' with %d schedules; override state %d until %lld",
             name.c_str(),
             schedules.size(),
             static_cast<int>(overrideState),

--- a/components/peripherals/peripherals/valve/ValveSchedule.hpp
+++ b/components/peripherals/peripherals/valve/ValveSchedule.hpp
@@ -47,6 +47,10 @@ using farmhub::peripherals::valve::ValveSchedule;
 template <>
 struct Converter<system_clock::time_point> {
     static void toJson(system_clock::time_point src, JsonVariant dst) {
+        if (src == system_clock::time_point{}) {
+            dst.set(nullptr);
+            return;
+        }
         time_t t = system_clock::to_time_t(src);
         tm tm {};
         (void) localtime_r(&t, &tm);
@@ -56,6 +60,9 @@ struct Converter<system_clock::time_point> {
     }
 
     static system_clock::time_point fromJson(JsonVariantConst src) {
+        if (src.isNull()) {
+            return system_clock::time_point{};
+        }
         tm tm {};
         strptime(src.as<const char*>(), "%FT%TZ", &tm);
         tm.tm_isdst = 0;


### PR DESCRIPTION
Previously when a device received `null` for `overrideState` or `overrideUntil`, it would crash.