### PR TITLE
Decrease I2C clock speed to 200 kHz

### DIFF
--- a/components/kernel/I2CManager.hpp
+++ b/components/kernel/I2CManager.hpp
@@ -58,7 +58,8 @@ public:
                   .clk_flags = 0,    // Use default clock flags
                   .master {
                       // TODO Allow clock speed to be configured
-                      .clk_speed = 400000,
+                      //      And use higher speed for internal I2C
+                      .clk_speed = 200000,
                   },
               },
           }) {


### PR DESCRIPTION
This is to make external connections to I2C peripheral more stable. We should only do this for the external I2C rail later.

This should get rid of the SHT3x logs like:

```
sht3x - Measurement is still running
sht3x - CRC check for temperature data failed
i2cdev - Could not write to device [0x44 at 0]: -1 (ESP_FAIL)
```

See:

- https://github.com/kivancsikert/ugly-duckling/issues/461