### PR TITLE
Enable internal pull-ups for I2C rails

### DIFF
--- a/components/kernel/I2CManager.hpp
+++ b/components/kernel/I2CManager.hpp
@@ -52,9 +52,10 @@ public:
               .cfg = {
                   .sda_io_num = bus->sda->getGpio(),
                   .scl_io_num = bus->scl->getGpio(),
-                  // TODO Allow this to be configred
-                  .sda_pullup_en = 0,
-                  .scl_pullup_en = 0,
+                  // Note: These enable ~45kOhm pull-ups; we still need stronger external ones
+                  //       for proper operation (~4.7kOhm, or even lower).
+                  .sda_pullup_en = 1,
+                  .scl_pullup_en = 1,
                   .clk_flags = 0,    // Use default clock flags
                   .master {
                       // TODO Allow clock speed to be configured


### PR DESCRIPTION
They seem to add somewhere in the ballpark of 45kOhm, which is very weak, and we still need external pull-ups. But at least it makes the warning message go away.