### PR TITLE
Add some tests for Configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,8 @@ jobs:
             -v ./artifacts/pytest-logs:/logs \
             -w /project/test/unit-tests \
             -e HOME=/tmp \
+            --add-host=host.docker.internal:host-gateway \
+            -e WOKWI_CLI_SERVER=ws://host.docker.internal:9177 \
             -e WOKWI_CLI_TOKEN=${{ secrets.WOKWI_CLI_TOKEN }} \
             lptr/pytest-embedded:latest \
             pytest \

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,16 @@
       "MIMode": "gdb",
       "miDebuggerPath": "${command:espIdf.getToolchainGdb}",
       "miDebuggerServerAddress": "localhost:3333"
+    },
+    {
+      "name": "Wokwi GDB integ-test",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/test/integ-tests/build/ugly-duckling-integ-tests.elf",
+      "cwd": "${workspaceFolder}",
+      "MIMode": "gdb",
+      "miDebuggerPath": "${command:espIdf.getToolchainGdb}",
+      "miDebuggerServerAddress": "localhost:3333"
     }
   ]
 }

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -88,7 +88,7 @@ public:
             return;
         }
         if (error) {
-            throw ConfigurationException("Cannot parse JSON configuration: " + std::string(error.c_str()) + json);
+            throw ConfigurationException("Cannot parse JSON configuration: " + std::string(error.c_str()) + ": " + json);
         }
         load(jsonDocument.as<JsonObject>());
     }

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -77,6 +77,10 @@ bool convertFromJson(JsonVariantConst src, JsonAsString& dst) {
     return true;
 }
 
+bool canConvertFromJson(JsonVariantConst src, const JsonAsString&) {
+  return src.is<std::string>();
+}
+
 class ConfigurationEntry {
 public:
     virtual ~ConfigurationEntry() = default;

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -399,4 +399,9 @@ void convertFromJson(JsonVariantConst src, D& dst) {
     dst = D { src.as<uint64_t>() };
 }
 
+template <Duration D>
+bool canConvertFromJson(JsonVariantConst src, const D&) {
+  return src.is<int64_t>();
+}
+
 }    // namespace std::chrono

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -163,7 +163,7 @@ public:
     }
 
     void load(const JsonObject& json) override {
-        if (!json[name].isNull() && json[name].is<JsonObject>()) {
+        if (json[name].is<JsonObject>()) {
             namePresentAtLoad = true;
             delegate->load(json[name]);
         } else {
@@ -220,7 +220,7 @@ public:
     }
 
     void load(const JsonObject& json) override {
-        if (!json[name].isNull() && json[name].is<T>()) {
+        if (json[name].is<T>()) {
             value = json[name].as<T>();
             configured = true;
         } else {

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -163,7 +163,7 @@ public:
     }
 
     void load(const JsonObject& json) override {
-        if (json[name].is<JsonVariant>()) {
+        if (!json[name].isNull() && json[name].is<JsonVariant>()) {
             namePresentAtLoad = true;
             delegate->load(json[name]);
         } else {

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -57,30 +57,6 @@ private:
     std::string value;
 };
 
-bool convertToJson(const JsonAsString& src, JsonVariant dst) {
-    const std::string& stringValue = src.get();
-    JsonDocument doc;
-    DeserializationError error = deserializeJson(doc, stringValue);
-
-    if (error) {
-        // Handle the error, if JSON parsing fails
-        return false;
-    }
-
-    dst.set(doc.as<JsonObject>());
-    return true;
-}
-bool convertFromJson(JsonVariantConst src, JsonAsString& dst) {
-    std::string value;
-    serializeJson(src, value);
-    dst.set(value);
-    return true;
-}
-
-bool canConvertFromJson(JsonVariantConst src, const JsonAsString&) {
-    return src.is<std::string>();
-}
-
 class ConfigurationEntry {
 public:
     virtual ~ConfigurationEntry() = default;
@@ -405,6 +381,35 @@ struct Converter<D> {
 
     static bool checkJson(JsonVariantConst src) {
         return src.is<int64_t>();
+    }
+};
+
+using farmhub::kernel::JsonAsString;
+
+template <>
+struct Converter<JsonAsString> {
+    static bool toJson(const JsonAsString& src, JsonVariant dst) {
+        const std::string& stringValue = src.get();
+        JsonDocument doc;
+        DeserializationError error = deserializeJson(doc, stringValue);
+
+        if (error) {
+            // Handle the error, if JSON parsing fails
+            return false;
+        }
+
+        dst.set(doc.as<JsonObject>());
+        return true;
+    }
+
+    static JsonAsString fromJson(JsonVariantConst src) {
+        std::string value;
+        serializeJson(src, value);
+        return JsonAsString(value);
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        return src.is<std::string>();
     }
 };
 

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -367,7 +367,8 @@ using namespace std::chrono;
 
 template <typename T>
 concept Duration = requires { typename T::rep; typename T::period; }
-    && std::is_same_v<T, std::chrono::duration<typename T::rep, typename T::period>>;
+    && std::is_same_v<T, std::chrono::duration<typename T::rep, typename T::period>>
+    && std::is_integral_v<typename T::rep>;
 
 template <Duration D>
 struct Converter<D> {

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -409,7 +409,7 @@ struct Converter<JsonAsString> {
         return JsonAsString(value);
     }
 
-    static bool checkJson(JsonVariantConst src) {
+    static bool checkJson(JsonVariantConst /* src */) {
         return true;
     }
 };

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -163,7 +163,7 @@ public:
     }
 
     void load(const JsonObject& json) override {
-        if (!json[name].isNull() && json[name].is<JsonVariant>()) {
+        if (!json[name].isNull() && json[name].is<JsonObject>()) {
             namePresentAtLoad = true;
             delegate->load(json[name]);
         } else {
@@ -220,7 +220,7 @@ public:
     }
 
     void load(const JsonObject& json) override {
-        if (!json[name].isNull() && json[name].is<JsonVariant>()) {
+        if (!json[name].isNull() && json[name].is<T>()) {
             value = json[name].as<T>();
             configured = true;
         } else {

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -78,7 +78,7 @@ bool convertFromJson(JsonVariantConst src, JsonAsString& dst) {
 }
 
 bool canConvertFromJson(JsonVariantConst src, const JsonAsString&) {
-  return src.is<std::string>();
+    return src.is<std::string>();
 }
 
 class ConfigurationEntry {
@@ -385,7 +385,7 @@ private:
 
 }    // namespace farmhub::kernel
 
-namespace std::chrono {
+namespace ArduinoJson {
 
 using namespace std::chrono;
 
@@ -394,18 +394,18 @@ concept Duration = requires { typename T::rep; typename T::period; }
     && std::is_same_v<T, std::chrono::duration<typename T::rep, typename T::period>>;
 
 template <Duration D>
-bool convertToJson(const D& src, JsonVariant dst) {
-    return dst.set(src.count());
-}
+struct Converter<D> {
+    static bool toJson(const D& src, JsonVariant dst) {
+        return dst.set(static_cast<int64_t>(src.count()));
+    }
 
-template <Duration D>
-void convertFromJson(JsonVariantConst src, D& dst) {
-    dst = D { src.as<uint64_t>() };
-}
+    static D fromJson(JsonVariantConst src) {
+        return D { src.as<int64_t>() };
+    }
 
-template <Duration D>
-bool canConvertFromJson(JsonVariantConst src, const D&) {
-  return src.is<int64_t>();
-}
+    static bool checkJson(JsonVariantConst src) {
+        return src.is<int64_t>();
+    }
+};
 
-}    // namespace std::chrono
+}    // namespace ArduinoJson

--- a/components/kernel/Configuration.hpp
+++ b/components/kernel/Configuration.hpp
@@ -6,11 +6,11 @@
 #include <list>
 #include <memory>
 #include <type_traits>
+#include <utility>
 
 #include <ArduinoJson.h>
 
 #include <FileSystem.hpp>
-#include <utility>
 
 using std::list;
 using std::ref;
@@ -410,7 +410,7 @@ struct Converter<JsonAsString> {
     }
 
     static bool checkJson(JsonVariantConst src) {
-        return src.is<std::string>();
+        return true;
     }
 };
 

--- a/components/kernel/LogJson.hpp
+++ b/components/kernel/LogJson.hpp
@@ -1,20 +1,25 @@
 #pragma once
 
 #include <ArduinoJson.h>
-
 #include <Log.hpp>
 
-namespace farmhub::kernel {
+namespace ArduinoJson {
 
-bool convertToJson(const Level& src, JsonVariant dst) {
-    return dst.set(static_cast<int>(src));
-}
-void convertFromJson(JsonVariantConst src, Level& dst) {
-    dst = static_cast<Level>(src.as<int>());
-}
+using farmhub::kernel::Level;
 
-bool canConvertFromJson(JsonVariantConst src, const Level&) {
-  return src.is<int>();
-}
+template <>
+struct Converter<Level> {
+    static bool toJson(const Level& src, JsonVariant dst) {
+        return dst.set(static_cast<int>(src));
+    }
 
-}    // namespace farmhub::kernel
+    static Level fromJson(JsonVariantConst src) {
+        return static_cast<Level>(src.as<int>());
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        return src.is<int>();
+    }
+};
+
+}    // namespace ArduinoJson

--- a/components/kernel/LogJson.hpp
+++ b/components/kernel/LogJson.hpp
@@ -13,4 +13,8 @@ void convertFromJson(JsonVariantConst src, Level& dst) {
     dst = static_cast<Level>(src.as<int>());
 }
 
+bool canConvertFromJson(JsonVariantConst src, const Level&) {
+  return src.is<int>();
+}
+
 }    // namespace farmhub::kernel

--- a/components/kernel/Pin.hpp
+++ b/components/kernel/Pin.hpp
@@ -248,7 +248,7 @@ struct Converter<PinPtr> {
         if (src.is<const char*>()) {
             return Pin::byName(src.as<const char*>());
         }
-        throw std::runtime_error(std::string("Invalid pin name: " + src.as<std::string>()).c_str());
+        throw std::runtime_error("Invalid pin name: " + src.as<std::string>());
     }
 
     static bool checkJson(JsonVariantConst src) {

--- a/components/kernel/drivers/MdnsDriver.hpp
+++ b/components/kernel/drivers/MdnsDriver.hpp
@@ -193,4 +193,8 @@ void convertFromJson(JsonVariantConst src, MdnsRecord& dst) {
     }
 }
 
+bool canConvertFromJson(JsonVariantConst src, const MdnsRecord&) {
+  return src.is<JsonObjectConst>();
+}
+
 }    // namespace farmhub::kernel::drivers

--- a/components/kernel/drivers/MdnsDriver.hpp
+++ b/components/kernel/drivers/MdnsDriver.hpp
@@ -160,41 +160,47 @@ private:
     NvsStore nvs { "mdns" };
 };
 
-bool convertToJson(const MdnsRecord& src, JsonVariant dst) {
-    auto jsonRecord = dst.to<JsonObject>();
-    if (src.hasHostname()) {
-        jsonRecord["hostname"] = src.hostname;
-    }
-    if (src.hasIp()) {
-        jsonRecord["ip"] = src.ipAsString();
-    }
-    if (src.hasPort()) {
-        jsonRecord["port"] = src.port;
-    }
-    return true;
-}
-void convertFromJson(JsonVariantConst src, MdnsRecord& dst) {
-    auto jsonRecord = src.as<JsonObjectConst>();
-    if (jsonRecord["hostname"].is<std::string>()) {
-        dst.hostname = jsonRecord["hostname"].as<std::string>();
-    } else {
-        dst.hostname = "";
-    }
-    if (jsonRecord["ip"].is<std::string>()) {
-        const char* ipStr = jsonRecord["ip"].as<const char*>();
-        dst.ip.addr = esp_ip4addr_aton(ipStr);
-    } else {
-        dst.ip.addr = 0;
-    }
-    if (jsonRecord["port"].is<int>()) {
-        dst.port = jsonRecord["port"].as<int>();
-    } else {
-        dst.port = 0;
-    }
-}
-
-bool canConvertFromJson(JsonVariantConst src, const MdnsRecord&) {
-  return src.is<JsonObjectConst>();
-}
-
 }    // namespace farmhub::kernel::drivers
+
+namespace ArduinoJson {
+
+using MdnsRecord = farmhub::kernel::drivers::MdnsRecord;
+
+template <>
+struct Converter<MdnsRecord> {
+    static bool toJson(const MdnsRecord& src, JsonVariant dst) {
+        auto jsonRecord = dst.to<JsonObject>();
+        if (src.hasHostname()) {
+            jsonRecord["hostname"] = src.hostname;
+        }
+        if (src.hasIp()) {
+            jsonRecord["ip"] = src.ipAsString();
+        }
+        if (src.hasPort()) {
+            jsonRecord["port"] = src.port;
+        }
+        return true;
+    }
+
+    static MdnsRecord fromJson(JsonVariantConst src) {
+        MdnsRecord dst;
+        auto jsonRecord = src.as<JsonObjectConst>();
+        if (jsonRecord["hostname"].is<std::string>()) {
+            dst.hostname = jsonRecord["hostname"].as<std::string>();
+        }
+        if (jsonRecord["ip"].is<std::string>()) {
+            const char* ipStr = jsonRecord["ip"].as<const char*>();
+            dst.ip.addr = esp_ip4addr_aton(ipStr);
+        }
+        if (jsonRecord["port"].is<int>()) {
+            dst.port = jsonRecord["port"].as<int>();
+        }
+        return dst;
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        return src.is<JsonObjectConst>();
+    }
+};
+
+}    // namespace ArduinoJson

--- a/components/kernel/test/ConfigurationTest.cpp
+++ b/components/kernel/test/ConfigurationTest.cpp
@@ -1,0 +1,99 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+#include <Configuration.hpp>
+
+using namespace farmhub::kernel;
+
+struct NestedConfig : ConfigurationSection {
+    Property<int> intValue { this, "intValue" };
+};
+
+struct TestConfig : ConfigurationSection {
+    Property<int> intValue { this, "intValue" };
+    Property<std::string> stringValue { this, "stringValue" };
+    Property<bool> boolValue { this, "boolValue" };
+    NamedConfigurationEntry<NestedConfig> nested { this, "nested" };
+};
+
+std::string toString(const ConfigurationEntry& config) {
+    JsonDocument json;
+    auto root = json.to<JsonObject>();
+    config.store(root);
+    std::string jsonString;
+    serializeJson(json, jsonString);
+    return jsonString;
+}
+
+TEST_CASE("empty configuration is stored as empty JSON") {
+    TestConfig config;
+    REQUIRE(toString(config) == R"({})");
+    REQUIRE(!config.intValue.hasValue());
+    REQUIRE(config.intValue.get() == 0);
+    REQUIRE(!config.stringValue.hasValue());
+    REQUIRE(config.stringValue.get() == "");
+    REQUIRE(!config.boolValue.hasValue());
+    REQUIRE(config.boolValue.get() == false);
+    REQUIRE(!config.nested.hasValue());
+    REQUIRE(!config.nested.get()->intValue.hasValue());
+    REQUIRE(config.nested.get()->intValue.get() == 0);
+}
+
+TEST_CASE("empty configuration can be loaded from empty JSON") {
+    TestConfig config;
+    config.loadFromString(R"({})");
+    REQUIRE(!config.intValue.hasValue());
+    REQUIRE(config.intValue.get() == 0);
+    REQUIRE(!config.stringValue.hasValue());
+    REQUIRE(config.stringValue.get() == "");
+    REQUIRE(!config.boolValue.hasValue());
+    REQUIRE(config.boolValue.get() == false);
+    REQUIRE(!config.nested.hasValue());
+    REQUIRE(!config.nested.get()->intValue.hasValue());
+    REQUIRE(config.nested.get()->intValue.get() == 0);
+}
+
+TEST_CASE("configuration with values is loaded from JSON and is stored as JSON") {
+    TestConfig config;
+    config.loadFromString(R"({"intValue":42,"stringValue":"hello","boolValue":true,"nested":{"intValue":7}})");
+    REQUIRE(config.intValue.hasValue());
+    REQUIRE(config.intValue.get() == 42);
+    REQUIRE(config.stringValue.hasValue());
+    REQUIRE(config.stringValue.get() == "hello");
+    REQUIRE(config.boolValue.hasValue());
+    REQUIRE(config.boolValue.get() == true);
+    REQUIRE(config.nested.hasValue());
+    REQUIRE(config.nested.get()->intValue.hasValue());
+    REQUIRE(config.nested.get()->intValue.get() == 7);
+    REQUIRE(toString(config) == R"({"intValue":42,"stringValue":"hello","boolValue":true,"nested":{"intValue":7}})");
+}
+
+struct ConfigWithDefaults : public ConfigurationSection {
+    Property<int> intValue { this, "intValue", 42 };
+    Property<std::string> stringValue { this, "stringValue", "default" };
+    Property<bool> boolValue { this, "boolValue", true };
+};
+
+TEST_CASE("configuration with default values loaded from empty JSON has default values") {
+    ConfigWithDefaults config;
+    REQUIRE(toString(config) == R"({})");
+    REQUIRE(!config.intValue.hasValue());
+    REQUIRE(config.intValue.get() == 42);
+    REQUIRE(!config.stringValue.hasValue());
+    REQUIRE(config.stringValue.get() == "default");
+    REQUIRE(!config.boolValue.hasValue());
+    REQUIRE(config.boolValue.get() == true);
+}
+
+TEST_CASE("configuration with default values loaded from non-empty JSON has actual values") {
+    ConfigWithDefaults config;
+    config.loadFromString(R"({"intValue": 100, "stringValue": "custom", "boolValue": false})");
+    REQUIRE(toString(config) == R"({"intValue":100,"stringValue":"custom","boolValue":false})");
+    REQUIRE(config.intValue.hasValue());
+    REQUIRE(config.intValue.get() == 100);
+    REQUIRE(config.stringValue.hasValue());
+    REQUIRE(config.stringValue.get() == "custom");
+    REQUIRE(config.boolValue.hasValue());
+    REQUIRE(config.boolValue.get() == false);
+}

--- a/components/kernel/test/ConfigurationTest.cpp
+++ b/components/kernel/test/ConfigurationTest.cpp
@@ -70,6 +70,20 @@ TEST_CASE("empty configuration can be loaded from JSON with null values") {
     REQUIRE(config.nested.get()->intValue.get() == 0);
 }
 
+TEST_CASE("configuration can be loaded from JSON with invalid values") {
+    TestConfig config;
+    config.loadFromString(R"({"intValue":"123","stringValue":123,"boolValue":"false","nested":"{}"})");
+    REQUIRE(!config.intValue.hasValue());
+    REQUIRE(config.intValue.get() == 0);
+    REQUIRE(!config.stringValue.hasValue());
+    REQUIRE(config.stringValue.get() == "");
+    REQUIRE(!config.boolValue.hasValue());
+    REQUIRE(config.boolValue.get() == false);
+    REQUIRE(!config.nested.hasValue());
+    REQUIRE(!config.nested.get()->intValue.hasValue());
+    REQUIRE(config.nested.get()->intValue.get() == 0);
+}
+
 TEST_CASE("configuration with values is loaded from JSON and is stored as JSON") {
     TestConfig config;
     config.loadFromString(R"({"intValue":42,"stringValue":"hello","boolValue":true,"nested":{"intValue":7}})");

--- a/components/kernel/test/ConfigurationTest.cpp
+++ b/components/kernel/test/ConfigurationTest.cpp
@@ -1,4 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
 
 #include <string>
 
@@ -53,7 +55,6 @@ TEST_CASE("empty configuration can be loaded from empty JSON") {
     REQUIRE(!config.nested.get()->intValue.hasValue());
     REQUIRE(config.nested.get()->intValue.get() == 0);
 }
-
 
 TEST_CASE("empty configuration can be loaded from JSON with null values") {
     TestConfig config;
@@ -124,5 +125,10 @@ TEST_CASE("configuration with default values loaded from non-empty JSON has actu
     REQUIRE(config.nested.get()->intValue.get() == 200);
 }
 
-// TODO Add some tests for invalid JSON handling
-// TODO Add some tests for properties not defined in the configuration type
+TEST_CASE("throws on invalid JSON") {
+    TestConfig config;
+    REQUIRE_THROWS_MATCHES(
+        config.loadFromString("NOT JSON"),
+        ConfigurationException,
+        Catch::Matchers::Message("ConfigurationException: Cannot parse JSON configuration: InvalidInput: NOT JSON"));
+}

--- a/components/kernel/test/ConfigurationTest.cpp
+++ b/components/kernel/test/ConfigurationTest.cpp
@@ -54,6 +54,21 @@ TEST_CASE("empty configuration can be loaded from empty JSON") {
     REQUIRE(config.nested.get()->intValue.get() == 0);
 }
 
+
+TEST_CASE("empty configuration can be loaded from JSON with null values") {
+    TestConfig config;
+    config.loadFromString(R"({"intValue":null,"stringValue":null,"boolValue":null,"nested":null})");
+    REQUIRE(!config.intValue.hasValue());
+    REQUIRE(config.intValue.get() == 0);
+    REQUIRE(!config.stringValue.hasValue());
+    REQUIRE(config.stringValue.get() == "");
+    REQUIRE(!config.boolValue.hasValue());
+    REQUIRE(config.boolValue.get() == false);
+    REQUIRE(!config.nested.hasValue());
+    REQUIRE(!config.nested.get()->intValue.hasValue());
+    REQUIRE(config.nested.get()->intValue.get() == 0);
+}
+
 TEST_CASE("configuration with values is loaded from JSON and is stored as JSON") {
     TestConfig config;
     config.loadFromString(R"({"intValue":42,"stringValue":"hello","boolValue":true,"nested":{"intValue":7}})");
@@ -110,5 +125,4 @@ TEST_CASE("configuration with default values loaded from non-empty JSON has actu
 }
 
 // TODO Add some tests for invalid JSON handling
-// TODO Add some tests for null values
 // TODO Add some tests for properties not defined in the configuration type

--- a/components/kernel/test/ConfigurationTest.cpp
+++ b/components/kernel/test/ConfigurationTest.cpp
@@ -73,6 +73,7 @@ struct ConfigWithDefaults : public ConfigurationSection {
     Property<int> intValue { this, "intValue", 42 };
     Property<std::string> stringValue { this, "stringValue", "default" };
     Property<bool> boolValue { this, "boolValue", true };
+    // TODO Add some nested configuration with defaults
 };
 
 TEST_CASE("configuration with default values loaded from empty JSON has default values") {
@@ -97,3 +98,7 @@ TEST_CASE("configuration with default values loaded from non-empty JSON has actu
     REQUIRE(config.boolValue.hasValue());
     REQUIRE(config.boolValue.get() == false);
 }
+
+// TODO Add some tests for invalid JSON handling
+// TODO Add some tests for null values
+// TODO Add some tests for properties not defined in the configuration type

--- a/components/kernel/test/ConfigurationTest.cpp
+++ b/components/kernel/test/ConfigurationTest.cpp
@@ -2,10 +2,13 @@
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_exception.hpp>
 
+#include <chrono>
 #include <string>
 
 #include <Configuration.hpp>
 
+using namespace std::chrono;
+using namespace std::chrono_literals;
 using namespace farmhub::kernel;
 
 struct TestNestedConfig : ConfigurationSection {
@@ -16,6 +19,7 @@ struct TestConfig : ConfigurationSection {
     Property<int> intValue { this, "intValue" };
     Property<std::string> stringValue { this, "stringValue" };
     Property<bool> boolValue { this, "boolValue" };
+    Property<seconds> secondsValue { this, "secondsValue" };
     NamedConfigurationEntry<TestNestedConfig> nested { this, "nested" };
 };
 
@@ -37,6 +41,8 @@ TEST_CASE("empty configuration is stored as empty JSON") {
     REQUIRE(config.stringValue.get() == "");
     REQUIRE(!config.boolValue.hasValue());
     REQUIRE(config.boolValue.get() == false);
+    REQUIRE(!config.secondsValue.hasValue());
+    REQUIRE(config.secondsValue.get() == 0s);
     REQUIRE(!config.nested.hasValue());
     REQUIRE(!config.nested.get()->intValue.hasValue());
     REQUIRE(config.nested.get()->intValue.get() == 0);
@@ -51,6 +57,8 @@ TEST_CASE("empty configuration can be loaded from empty JSON") {
     REQUIRE(config.stringValue.get() == "");
     REQUIRE(!config.boolValue.hasValue());
     REQUIRE(config.boolValue.get() == false);
+    REQUIRE(!config.secondsValue.hasValue());
+    REQUIRE(config.secondsValue.get() == 0s);
     REQUIRE(!config.nested.hasValue());
     REQUIRE(!config.nested.get()->intValue.hasValue());
     REQUIRE(config.nested.get()->intValue.get() == 0);
@@ -58,13 +66,15 @@ TEST_CASE("empty configuration can be loaded from empty JSON") {
 
 TEST_CASE("empty configuration can be loaded from JSON with null values") {
     TestConfig config;
-    config.loadFromString(R"({"intValue":null,"stringValue":null,"boolValue":null,"nested":null})");
+    config.loadFromString(R"({"intValue":null,"stringValue":null,"boolValue":null,"secondsValue":null,"nested":null})");
     REQUIRE(!config.intValue.hasValue());
     REQUIRE(config.intValue.get() == 0);
     REQUIRE(!config.stringValue.hasValue());
     REQUIRE(config.stringValue.get() == "");
     REQUIRE(!config.boolValue.hasValue());
     REQUIRE(config.boolValue.get() == false);
+    REQUIRE(!config.secondsValue.hasValue());
+    REQUIRE(config.secondsValue.get() == 0s);
     REQUIRE(!config.nested.hasValue());
     REQUIRE(!config.nested.get()->intValue.hasValue());
     REQUIRE(config.nested.get()->intValue.get() == 0);
@@ -72,13 +82,15 @@ TEST_CASE("empty configuration can be loaded from JSON with null values") {
 
 TEST_CASE("configuration can be loaded from JSON with invalid values") {
     TestConfig config;
-    config.loadFromString(R"({"intValue":"123","stringValue":123,"boolValue":"false","nested":"{}"})");
+    config.loadFromString(R"({"intValue":"123","stringValue":123,"boolValue":"false","secondsValue":"60","nested":"{}"})");
     REQUIRE(!config.intValue.hasValue());
     REQUIRE(config.intValue.get() == 0);
     REQUIRE(!config.stringValue.hasValue());
     REQUIRE(config.stringValue.get() == "");
     REQUIRE(!config.boolValue.hasValue());
     REQUIRE(config.boolValue.get() == false);
+    REQUIRE(!config.secondsValue.hasValue());
+    REQUIRE(config.secondsValue.get() == 0s);
     REQUIRE(!config.nested.hasValue());
     REQUIRE(!config.nested.get()->intValue.hasValue());
     REQUIRE(config.nested.get()->intValue.get() == 0);
@@ -86,17 +98,19 @@ TEST_CASE("configuration can be loaded from JSON with invalid values") {
 
 TEST_CASE("configuration with values is loaded from JSON and is stored as JSON") {
     TestConfig config;
-    config.loadFromString(R"({"intValue":42,"stringValue":"hello","boolValue":true,"nested":{"intValue":7}})");
+    config.loadFromString(R"({"intValue":42,"stringValue":"hello","boolValue":true,"secondsValue":60,"nested":{"intValue":7}})");
     REQUIRE(config.intValue.hasValue());
     REQUIRE(config.intValue.get() == 42);
     REQUIRE(config.stringValue.hasValue());
     REQUIRE(config.stringValue.get() == "hello");
     REQUIRE(config.boolValue.hasValue());
     REQUIRE(config.boolValue.get() == true);
+    REQUIRE(config.secondsValue.hasValue());
+    REQUIRE(config.secondsValue.get() == 60s);
     REQUIRE(config.nested.hasValue());
     REQUIRE(config.nested.get()->intValue.hasValue());
     REQUIRE(config.nested.get()->intValue.get() == 7);
-    REQUIRE(toString(config) == R"({"intValue":42,"stringValue":"hello","boolValue":true,"nested":{"intValue":7}})");
+    REQUIRE(toString(config) == R"({"intValue":42,"stringValue":"hello","boolValue":true,"secondsValue":60,"nested":{"intValue":7}})");
 }
 
 struct TestNestedConfigWithDefaults : ConfigurationSection {
@@ -107,6 +121,7 @@ struct TestConfigWithDefaults : public ConfigurationSection {
     Property<int> intValue { this, "intValue", 42 };
     Property<std::string> stringValue { this, "stringValue", "default" };
     Property<bool> boolValue { this, "boolValue", true };
+    Property<std::chrono::seconds> secondsValue { this, "secondsValue", 30s };
     NamedConfigurationEntry<TestNestedConfigWithDefaults> nested { this, "nested" };
 };
 
@@ -119,6 +134,8 @@ TEST_CASE("configuration with default values loaded from empty JSON has default 
     REQUIRE(config.stringValue.get() == "default");
     REQUIRE(!config.boolValue.hasValue());
     REQUIRE(config.boolValue.get() == true);
+    REQUIRE(!config.secondsValue.hasValue());
+    REQUIRE(config.secondsValue.get() == 30s);
     REQUIRE(!config.nested.hasValue());
     REQUIRE(!config.nested.get()->intValue.hasValue());
     REQUIRE(config.nested.get()->intValue.get() == 100);
@@ -126,14 +143,16 @@ TEST_CASE("configuration with default values loaded from empty JSON has default 
 
 TEST_CASE("configuration with default values loaded from non-empty JSON has actual values") {
     TestConfigWithDefaults config;
-    config.loadFromString(R"({"intValue": 100, "stringValue": "custom", "boolValue": false, "nested": {"intValue": 200}})");
-    REQUIRE(toString(config) == R"({"intValue":100,"stringValue":"custom","boolValue":false,"nested":{"intValue":200}})");
+    config.loadFromString(R"({"intValue": 100, "stringValue": "custom", "boolValue": false, "secondsValue": 45, "nested": {"intValue": 200}})");
+    REQUIRE(toString(config) == R"({"intValue":100,"stringValue":"custom","boolValue":false,"secondsValue":45,"nested":{"intValue":200}})");
     REQUIRE(config.intValue.hasValue());
     REQUIRE(config.intValue.get() == 100);
     REQUIRE(config.stringValue.hasValue());
     REQUIRE(config.stringValue.get() == "custom");
     REQUIRE(config.boolValue.hasValue());
     REQUIRE(config.boolValue.get() == false);
+    REQUIRE(config.secondsValue.hasValue());
+    REQUIRE(config.secondsValue.get() == 45s);
     REQUIRE(config.nested.hasValue());
     REQUIRE(config.nested.get()->intValue.hasValue());
     REQUIRE(config.nested.get()->intValue.get() == 200);

--- a/components/kernel/test/ConfigurationTest.cpp
+++ b/components/kernel/test/ConfigurationTest.cpp
@@ -6,7 +6,7 @@
 
 using namespace farmhub::kernel;
 
-struct NestedConfig : ConfigurationSection {
+struct TestNestedConfig : ConfigurationSection {
     Property<int> intValue { this, "intValue" };
 };
 
@@ -14,7 +14,7 @@ struct TestConfig : ConfigurationSection {
     Property<int> intValue { this, "intValue" };
     Property<std::string> stringValue { this, "stringValue" };
     Property<bool> boolValue { this, "boolValue" };
-    NamedConfigurationEntry<NestedConfig> nested { this, "nested" };
+    NamedConfigurationEntry<TestNestedConfig> nested { this, "nested" };
 };
 
 std::string toString(const ConfigurationEntry& config) {
@@ -69,15 +69,19 @@ TEST_CASE("configuration with values is loaded from JSON and is stored as JSON")
     REQUIRE(toString(config) == R"({"intValue":42,"stringValue":"hello","boolValue":true,"nested":{"intValue":7}})");
 }
 
-struct ConfigWithDefaults : public ConfigurationSection {
+struct TestNestedConfigWithDefaults : ConfigurationSection {
+    Property<int> intValue { this, "intValue", 100 };
+};
+
+struct TestConfigWithDefaults : public ConfigurationSection {
     Property<int> intValue { this, "intValue", 42 };
     Property<std::string> stringValue { this, "stringValue", "default" };
     Property<bool> boolValue { this, "boolValue", true };
-    // TODO Add some nested configuration with defaults
+    NamedConfigurationEntry<TestNestedConfigWithDefaults> nested { this, "nested" };
 };
 
 TEST_CASE("configuration with default values loaded from empty JSON has default values") {
-    ConfigWithDefaults config;
+    TestConfigWithDefaults config;
     REQUIRE(toString(config) == R"({})");
     REQUIRE(!config.intValue.hasValue());
     REQUIRE(config.intValue.get() == 42);
@@ -85,18 +89,24 @@ TEST_CASE("configuration with default values loaded from empty JSON has default 
     REQUIRE(config.stringValue.get() == "default");
     REQUIRE(!config.boolValue.hasValue());
     REQUIRE(config.boolValue.get() == true);
+    REQUIRE(!config.nested.hasValue());
+    REQUIRE(!config.nested.get()->intValue.hasValue());
+    REQUIRE(config.nested.get()->intValue.get() == 100);
 }
 
 TEST_CASE("configuration with default values loaded from non-empty JSON has actual values") {
-    ConfigWithDefaults config;
-    config.loadFromString(R"({"intValue": 100, "stringValue": "custom", "boolValue": false})");
-    REQUIRE(toString(config) == R"({"intValue":100,"stringValue":"custom","boolValue":false})");
+    TestConfigWithDefaults config;
+    config.loadFromString(R"({"intValue": 100, "stringValue": "custom", "boolValue": false, "nested": {"intValue": 200}})");
+    REQUIRE(toString(config) == R"({"intValue":100,"stringValue":"custom","boolValue":false,"nested":{"intValue":200}})");
     REQUIRE(config.intValue.hasValue());
     REQUIRE(config.intValue.get() == 100);
     REQUIRE(config.stringValue.hasValue());
     REQUIRE(config.stringValue.get() == "custom");
     REQUIRE(config.boolValue.hasValue());
     REQUIRE(config.boolValue.get() == false);
+    REQUIRE(config.nested.hasValue());
+    REQUIRE(config.nested.get()->intValue.hasValue());
+    REQUIRE(config.nested.get()->intValue.get() == 200);
 }
 
 // TODO Add some tests for invalid JSON handling

--- a/components/peripherals-api/peripherals/api/IDoor.hpp
+++ b/components/peripherals-api/peripherals/api/IDoor.hpp
@@ -37,7 +37,7 @@ using farmhub::peripherals::api::DoorState;
 
 template <>
 struct Converter<DoorState> {
-    static bool toJson(DoorState src, JsonVariant dst) {
+    static bool toJson(const DoorState src, JsonVariant dst) {
         return dst.set(static_cast<int>(src));
     }
 

--- a/components/peripherals-api/peripherals/api/IDoor.hpp
+++ b/components/peripherals-api/peripherals/api/IDoor.hpp
@@ -13,16 +13,6 @@ enum class DoorState : int8_t {
     Open = 1
 };
 
-bool convertToJson(const DoorState& src, JsonVariant dst) {
-    return dst.set(static_cast<int>(src));
-}
-void convertFromJson(JsonVariantConst src, DoorState& dst) {
-    dst = static_cast<DoorState>(src.as<int>());
-}
-bool canConvertFromJson(JsonVariantConst src, const DoorState&) {
-  return src.is<int>();
-}
-
 struct IDoor : virtual IPeripheral {
     /**
      * @brief Transition the door to a new state.
@@ -40,3 +30,24 @@ struct IDoor : virtual IPeripheral {
 };
 
 }    // namespace farmhub::peripherals::api
+
+namespace ArduinoJson {
+
+using farmhub::peripherals::api::DoorState;
+
+template <>
+struct Converter<DoorState> {
+    static bool toJson(DoorState src, JsonVariant dst) {
+        return dst.set(static_cast<int>(src));
+    }
+
+    static DoorState fromJson(JsonVariantConst src) {
+        return static_cast<DoorState>(src.as<int>());
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        return src.is<int>();
+    }
+};
+
+}    // namespace ArduinoJson

--- a/components/peripherals-api/peripherals/api/IDoor.hpp
+++ b/components/peripherals-api/peripherals/api/IDoor.hpp
@@ -19,6 +19,9 @@ bool convertToJson(const DoorState& src, JsonVariant dst) {
 void convertFromJson(JsonVariantConst src, DoorState& dst) {
     dst = static_cast<DoorState>(src.as<int>());
 }
+bool canConvertFromJson(JsonVariantConst src, const DoorState&) {
+  return src.is<int>();
+}
 
 struct IDoor : virtual IPeripheral {
     /**

--- a/components/peripherals-api/peripherals/api/IValve.hpp
+++ b/components/peripherals-api/peripherals/api/IValve.hpp
@@ -50,7 +50,7 @@ using farmhub::peripherals::api::ValveState;
 
 template <>
 struct Converter<ValveState> {
-    static void toJson(ValveState src, JsonVariant dst) {
+    static void toJson(const ValveState src, JsonVariant dst) {
         switch (src) {
             case ValveState::Closed:
                 dst.set("Closed");

--- a/components/peripherals-api/peripherals/api/TargetState.hpp
+++ b/components/peripherals-api/peripherals/api/TargetState.hpp
@@ -33,7 +33,7 @@ using farmhub::peripherals::api::TargetState;
 
 template <>
 struct Converter<TargetState> {
-    static void toJson(TargetState src, JsonVariant dst) {
+    static void toJson(const TargetState src, JsonVariant dst) {
         switch (src) {
             case TargetState::Closed:
                 dst.set("Closed");

--- a/components/peripherals/peripherals/door/Door.hpp
+++ b/components/peripherals/peripherals/door/Door.hpp
@@ -44,6 +44,9 @@ bool convertToJson(const OperationState& src, JsonVariant dst) {
 void convertFromJson(JsonVariantConst src, OperationState& dst) {
     dst = static_cast<OperationState>(src.as<int>());
 }
+bool canConvertFromJson(JsonVariantConst src, const OperationState&) {
+  return src.is<int>();
+}
 
 class DoorSettings final
     : public ConfigurationSection {

--- a/components/peripherals/peripherals/door/Door.hpp
+++ b/components/peripherals/peripherals/door/Door.hpp
@@ -38,16 +38,6 @@ enum class OperationState : uint8_t {
     WatchdogTimeout,
 };
 
-bool convertToJson(const OperationState& src, JsonVariant dst) {
-    return dst.set(static_cast<int>(src));
-}
-void convertFromJson(JsonVariantConst src, OperationState& dst) {
-    dst = static_cast<OperationState>(src.as<int>());
-}
-bool canConvertFromJson(JsonVariantConst src, const OperationState&) {
-  return src.is<int>();
-}
-
 class DoorSettings final
     : public ConfigurationSection {
 public:
@@ -366,3 +356,24 @@ inline PeripheralFactory makeFactory(const std::map<std::string, std::shared_ptr
 }
 
 }    // namespace farmhub::peripherals::door
+
+namespace ArduinoJson {
+
+using farmhub::peripherals::door::OperationState;
+
+template <>
+struct Converter<OperationState> {
+    static bool toJson(const OperationState& src, JsonVariant dst) {
+        return dst.set(static_cast<int>(src));
+    }
+
+    static OperationState fromJson(JsonVariantConst src) {
+        return static_cast<OperationState>(src.as<int>());
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        return src.is<int>();
+    }
+};
+
+}    // namespace ArduinoJson

--- a/components/peripherals/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/components/peripherals/peripherals/fence/ElectricFenceMonitor.hpp
@@ -28,19 +28,6 @@ public:
     Property<seconds> measurementFrequency { this, "measurementFrequency", 10s };
 };
 
-bool convertToJson(const FencePinConfig& src, JsonVariant dst) {
-    dst["pin"] = src.pin;
-    dst["voltage"] = src.voltage;
-    return true;
-}
-void convertFromJson(JsonVariantConst src, FencePinConfig& dst) {
-    dst.pin = src["pin"];
-    dst.voltage = src["voltage"];
-}
-bool canConvertFromJson(JsonVariantConst src, const FencePinConfig&) {
-  return src.is<JsonObjectConst>();
-}
-
 class ElectricFenceMonitor final
     : public Peripheral {
 public:
@@ -115,3 +102,29 @@ inline PeripheralFactory makeFactory() {
 }
 
 }    // namespace farmhub::peripherals::fence
+
+namespace ArduinoJson {
+
+using farmhub::peripherals::fence::FencePinConfig;
+
+template <>
+struct Converter<FencePinConfig> {
+    static bool toJson(const FencePinConfig& src, JsonVariant dst) {
+        dst["pin"] = src.pin;
+        dst["voltage"] = src.voltage;
+        return true;
+    }
+
+    static FencePinConfig fromJson(JsonVariantConst src) {
+        FencePinConfig dst;
+        dst.pin = src["pin"];
+        dst.voltage = src["voltage"];
+        return dst;
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        return src.is<JsonObjectConst>();
+    }
+};
+
+}    // namespace ArduinoJson

--- a/components/peripherals/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/components/peripherals/peripherals/fence/ElectricFenceMonitor.hpp
@@ -37,6 +37,9 @@ void convertFromJson(JsonVariantConst src, FencePinConfig& dst) {
     dst.pin = src["pin"];
     dst.voltage = src["voltage"];
 }
+bool canConvertFromJson(JsonVariantConst src, const FencePinConfig&) {
+  return src.is<JsonObjectConst>();
+}
 
 class ElectricFenceMonitor final
     : public Peripheral {

--- a/components/peripherals/peripherals/valve/ValveSettings.hpp
+++ b/components/peripherals/peripherals/valve/ValveSettings.hpp
@@ -111,4 +111,8 @@ void convertFromJson(JsonVariantConst src, ValveControlStrategyType& dst) {
     }
 }
 
+bool canConvertFromJson(JsonVariantConst src, const ValveControlStrategyType&) {
+  return src.is<std::string>();
+}
+
 }    // namespace farmhub::peripherals::valve

--- a/components/peripherals/peripherals/valve/ValveSettings.hpp
+++ b/components/peripherals/peripherals/valve/ValveSettings.hpp
@@ -80,39 +80,46 @@ public:
     }
 };
 
-// JSON: ValveControlStrategyType
-
-bool convertToJson(const ValveControlStrategyType& src, JsonVariant dst) {
-    switch (src) {
-        case ValveControlStrategyType::NormallyOpen:
-            return dst.set("NO");
-        case ValveControlStrategyType::NormallyClosed:
-            return dst.set("NC");
-        case ValveControlStrategyType::Latching:
-            return dst.set("latching");
-        default:
-            LOGE("Unknown strategy: %d",
-                static_cast<int>(src));
-            return dst.set("NC");
-    }
-}
-void convertFromJson(JsonVariantConst src, ValveControlStrategyType& dst) {
-    auto strategy = src.as<std::string>();
-    if (strategy == "NO") {
-        dst = ValveControlStrategyType::NormallyOpen;
-    } else if (strategy == "NC") {
-        dst = ValveControlStrategyType::NormallyClosed;
-    } else if (strategy == "latching") {
-        dst = ValveControlStrategyType::Latching;
-    } else {
-        LOGE("Unknown strategy: %s",
-            strategy.c_str());
-        dst = ValveControlStrategyType::NormallyClosed;
-    }
-}
-
-bool canConvertFromJson(JsonVariantConst src, const ValveControlStrategyType&) {
-  return src.is<std::string>();
-}
-
 }    // namespace farmhub::peripherals::valve
+
+namespace ArduinoJson {
+
+using farmhub::peripherals::valve::ValveControlStrategyType;
+
+template <>
+struct Converter<ValveControlStrategyType> {
+    static bool toJson(const ValveControlStrategyType& src, JsonVariant dst) {
+        switch (src) {
+            case ValveControlStrategyType::NormallyOpen:
+                return dst.set("NO");
+            case ValveControlStrategyType::NormallyClosed:
+                return dst.set("NC");
+            case ValveControlStrategyType::Latching:
+                return dst.set("latching");
+            default:
+                LOGE("Unknown strategy: %d", static_cast<int>(src));
+                return dst.set("NC");
+        }
+    }
+
+    static ValveControlStrategyType fromJson(JsonVariantConst src) {
+        auto strategy = src.as<std::string>();
+        if (strategy == "NO") {
+            return ValveControlStrategyType::NormallyOpen;
+        }
+        if (strategy == "NC") {
+            return ValveControlStrategyType::NormallyClosed;
+        }
+        if (strategy == "latching") {
+            return ValveControlStrategyType::Latching;
+        }
+        LOGE("Unknown strategy: %s", strategy.c_str());
+        return ValveControlStrategyType::NormallyClosed;
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        return src.is<std::string>();
+    }
+};
+
+}    // namespace ArduinoJson

--- a/components/utils/utils/scheduling/IScheduler.hpp
+++ b/components/utils/utils/scheduling/IScheduler.hpp
@@ -43,7 +43,7 @@ using namespace std::chrono;
 
 template <>
 struct Converter<system_clock::time_point> {
-    static void toJson(system_clock::time_point src, JsonVariant dst) {
+    static void toJson(const system_clock::time_point src, JsonVariant dst) {
         if (src == system_clock::time_point {}) {
             dst.set(nullptr);
             return;


### PR DESCRIPTION
This actually changes how we handle `null` values for nested objects (spoiler: they are considered unconfigured now!), and standardizes on using `Converter<T>`-style JSON converters everywhere instead of raw functions.

Fixes #491.