### PR TITLE
Test crash dump handling -- DO NOT MERGE

### DIFF
--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -422,8 +422,8 @@ static void startDevice() {
                 LOGI("WiFi reset triggered after %lld ms", duration.count());
                 performFactoryReset(statusLed, false);
             } else if (duration >= 200ms) {
-                LOGD("Publishing telemetry after %lld ms", duration.count());
-                telemetryPublisher->requestTelemetryPublishing();
+                LOGD("Intentionally crashing after %lld ms", duration.count());
+                esp_system_abort("Intentional crash; testing core dump handling");
             }
         } });
 


### PR DESCRIPTION
This is a PR to keep around to test crash reporting.

It can be used to produce a variant of the firmware that intentionally panics when the BOOT button is pressed, thus producing a crash report that is uploaded to the server on the next boot.

> [!NOTE]
> This does not work with a Wokwi-emulated device, and requires real hardware. This is because crash reports are persisted to flash, and are published on the next restart, but Wokwi does not preserve emulated flash state between restarts.