### PR TITLE
Use ugly duckling instead of farmhub everywhere

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
             ud_debug: 1
 
     env:
-      # Enable verbose logging in debug artifacts for farmhub tags
-      FARMHUB_LOG_VERBOSE: ""
+      # Enable verbose logging in debug artifacts for ugly duckling tags
+      UD_LOG_VERBOSE: ""
 
     steps:
       - uses: actions/checkout@v5
@@ -68,7 +68,7 @@ jobs:
             idf.py build \
               -DUD_DEBUG=${{ matrix.ud_debug }} \
               -DFSUPLOAD=1 \
-              -DFARMHUB_LOG_VERBOSE=${{ env.FARMHUB_LOG_VERBOSE }} \
+              -DUD_LOG_VERBOSE=${{ env.UD_LOG_VERBOSE }} \
               && \
             esp-idf-sbom create -o build/ugly-duckling.spdx build/project_description.json && \
             pyspdxtools --novalidation --infile build/ugly-duckling.spdx --outfile build/ugly-duckling.spdx.json && \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ See [README.md](README.md) for configuration storage layout, build, flash, and d
 
 - Follow `.editorconfig`: LF endings, 4-space indent (2 for JSON/YAML/Markdown). C++ is formatted with WebKit-flavored `.clang-format` (attached braces, left-aligned pointers, no single-line functions).
 - Static analysis via `.clang-tidy` (warnings-as-errors). Regenerate the compile DB with `python ./generate-clang-tidy-compile-db.py` and run `clang-tidy -p build/clang-tidy ...`.
-- Naming: types in PascalCase (`UglyDucklingMk6`), functions/methods camelCase, constants/macros UPPER_SNAKE (`UD_GEN`, `FARMHUB_DEBUG`); keep namespaces compact per config.
+- Naming: types in PascalCase (`UglyDucklingMk6`), functions/methods camelCase, constants/macros UPPER_SNAKE (`UD_GEN`, `UD_DEBUG`); keep namespaces compact per config.
 - Markdown: keep headings sequential, lists properly indented, and wrap code blocks in fences; follow markdownlint defaults (no trailing spaces, blank line before lists and headings).
 
 ## Testing Guidelines

--- a/DeviceCommon.cmake
+++ b/DeviceCommon.cmake
@@ -72,13 +72,13 @@ if(UD_DEBUG STREQUAL "")
     set(UD_DEBUG 0)
 endif()
 
-if(NOT DEFINED FARMHUB_LOG_VERBOSE)
-    set(FARMHUB_LOG_VERBOSE "$ENV{FARMHUB_LOG_VERBOSE}")
+if(NOT DEFINED UD_LOG_VERBOSE)
+    set(UD_LOG_VERBOSE "$ENV{UD_LOG_VERBOSE}")
 endif()
 
 if(UD_DEBUG)
-    add_compile_definitions(FARMHUB_DEBUG)
-    add_compile_definitions(FARMHUB_LOG_VERBOSE="${FARMHUB_LOG_VERBOSE}")
+    add_compile_definitions(UD_DEBUG)
+    add_compile_definitions(UD_LOG_VERBOSE="${UD_LOG_VERBOSE}")
     add_compile_definitions(DUMP_MQTT)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ![Build badge](https://github.com/cornucopia-machines/ugly-duckling/actions/workflows/build.yml/badge.svg)
 
-Ugly Duckling is a firmware for IoT devices participating in the FarmHub ecosystem.
+Ugly Duckling is a firmware for IoT devices participating in the Cornucopia ecosystem like the GrowMachine.
 
 The devices are built around the Espressif ESP32 micro-controller using the ESP-IDF framework and FreeRTOS.
-The devices can report telemetry to, and receive configuration and commands from the FarmHub server via MQTT over WiFi.
+The devices can report telemetry to, and receive configuration and commands from the Cornucopia server via MQTT over WiFi.
 They can also receive firmware updates via HTTP(S).
 
 Devices are identified by a location (denoting the installation site) and a unique instance name.
@@ -46,7 +46,7 @@ It includes both the device identity and the MQTT broker settings:
 ```jsonc
 {
   "instance": "chicken-door", // the instance name, defaults to MAC address
-  "location": "my-farm", // the name of the location the device is installed at
+  "location": "my-garden", // the name of the location the device is installed at
   "host": "...", // broker host name
   "port": 1883, // broker port, defaults to 1883
   "clientId": "chicken-door", // client ID, defaults to "ugly-duckling-$instance" if omitted
@@ -121,7 +121,7 @@ Once the device receives such configuration, it stores it under the `$FUNCTION_N
 
 ## Remote commands
 
-FarmHub devices and their peripherals both support receiving commands via MQTT.
+Ugly duckling devices and their peripherals both support receiving commands via MQTT.
 Commands are triggered via retained MQTT messages sent to `$DEVICE_ROOT/commands/$COMMAND` for devices, and `$DEVICE_`.
 They typically respond under `$DEVICE_ROOT/responses/$COMMAND`.
 

--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -17,7 +17,7 @@
 #include <driver/gpio.h>
 #include <esp_app_desc.h>
 
-static const char* const farmhubVersion = reinterpret_cast<const char*>(esp_app_get_description()->version);
+static const char* const firmwareVersion = reinterpret_cast<const char*>(esp_app_get_description()->version);
 
 #include <BatteryManager.hpp>
 #include <Console.hpp>
@@ -39,10 +39,10 @@ static const char* const farmhubVersion = reinterpret_cast<const char*>(esp_app_
 #include <peripherals/Peripheral.hpp>
 
 using namespace std::chrono;
-using namespace farmhub::devices;
-using namespace farmhub::functions;
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::devices;
+using namespace cornucopia::ugly_duckling::functions;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
 
 #ifdef CONFIG_HEAP_TRACING
 #include <esp_heap_trace.h>
@@ -371,7 +371,7 @@ static void startDevice() {
     auto powerManager = std::make_shared<PowerManager>(settings->sleepWhenIdle.get());
 
     auto logRecords = std::make_shared<Queue<LogRecord>>("logs",
-#ifdef FARMHUB_DEBUG
+#ifdef UD_DEBUG
         128
 #else
         32
@@ -380,15 +380,15 @@ static void startDevice() {
     ConsoleProvider::init(logRecords, settings->publishLogs.get());
 
     LOGD("\n"
-         "   ______                   _    _       _\n"
-         "  |  ____|                 | |  | |     | |\n"
-         "  | |__ __ _ _ __ _ __ ___ | |__| |_   _| |__\n"
-         "  |  __/ _` | '__| '_ ` _ \\|  __  | | | | '_ \\\n"
-         "  | | | (_| | |  | | | | | | |  | | |_| | |_) |\n"
-         "  |_|  \\__,_|_|  |_| |_| |_|_|  |_|\\__,_|_.__/ %s\n",
-        farmhubVersion);
-    LOGI("Initializing FarmHub kernel version %s on %s instance '%s' with hostname '%s' and MAC address %s",
-        farmhubVersion,
+         "   _   _       _         ____             _    _ _\n"
+         "  | | | | __ _| |_   _  |  _ \\ _   _  ___| | _| (_)_ __   __ _\n"
+         "  | | | |/ _` | | | | | | | | | | | |/ __| |/ / | | '_ \\ / _` |\n"
+         "  | |_| | (_| | | |_| | | |_| | |_| | (__|   <| | | | | | (_| |\n"
+         "   \\___/ \\__, |_|\\__, | |____/ \\__,_|\\___|_|\\_\\_|_|_| |_|\\__, |\n"
+         "         |___/   |___/                                    |___/ %s\n",
+        firmwareVersion);
+    LOGI("Initializing ugly duckling firmware version %s on %s instance '%s' with hostname '%s' and MAC address %s",
+        firmwareVersion,
         modelWithRevision.c_str(),
         networkConfig->instance.get().c_str(),
         networkConfig->getHostname().c_str(),
@@ -437,7 +437,7 @@ static void startDevice() {
         LOGD("No battery configured");
     }
 
-#ifdef FARMHUB_DEBUG
+#ifdef UD_DEBUG
     new DebugConsole(batteryManager, wifi);
 #endif
 
@@ -550,8 +550,8 @@ static void startDevice() {
             json["mac"] = getMacAddress();
             auto device = json["settings"].to<JsonObject>();
             settings->store(device);
-            json["version"] = farmhubVersion;
-#ifdef FARMHUB_DEBUG
+            json["version"] = firmwareVersion;
+#ifdef UD_DEBUG
             json["debug"] = true;
 #else
             json["debug"] = false;
@@ -573,7 +573,7 @@ static void startDevice() {
 
     LOGI("Device ready in %.2f s (kernel version %s on %s instance '%s' with hostname '%s' and IP '%s', SSID '%s', current time is %lld)",
         duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count() / 1000.0,
-        farmhubVersion,
+        firmwareVersion,
         modelWithRevision.c_str(),
         networkConfig->instance.get().c_str(),
         networkConfig->getHostname().c_str(),

--- a/components/devices/src/devices/DeviceDefinition.hpp
+++ b/components/devices/src/devices/DeviceDefinition.hpp
@@ -36,12 +36,12 @@
 #include <peripherals/light_sensor/Tsl2591.hpp>
 #include <peripherals/multiplexer/Xl9535.hpp>
 
-using namespace farmhub::functions;
-using namespace farmhub::kernel;
-using namespace farmhub::kernel::drivers;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::functions;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::devices {
+namespace cornucopia::ugly_duckling::devices {
 
 #define UD_DEFINE_PIN3(GPIO, VAR, STR) \
     const InternalPinPtr VAR = InternalPin::registerPin(STR, GPIO);
@@ -125,4 +125,4 @@ protected:
     }
 };
 
-}    // namespace farmhub::devices
+}    // namespace cornucopia::ugly_duckling::devices

--- a/components/devices/src/devices/DeviceSettings.hpp
+++ b/components/devices/src/devices/DeviceSettings.hpp
@@ -3,9 +3,9 @@
 #include <Configuration.hpp>
 #include <Pin.hpp>
 
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
-namespace farmhub::devices {
+namespace cornucopia::ugly_duckling::devices {
 
 struct DeviceSettings : ConfigurationSection {
     ArrayProperty<JsonAsString> peripherals { this, "peripherals" };
@@ -18,7 +18,7 @@ struct DeviceSettings : ConfigurationSection {
      */
     Property<seconds> publishInterval { this, "publishInterval", 5min };
     Property<Level> publishLogs { this, "publishLogs",
-#ifdef FARMHUB_DEBUG
+#ifdef UD_DEBUG
         Level::Verbose
 #else
         Level::Info
@@ -39,4 +39,4 @@ struct DeviceSettings : ConfigurationSection {
     Property<PinPtr> motorNSleepPin { this, "motorNSleepPin" };
 };
 
-}    // namespace farmhub::devices
+}    // namespace cornucopia::ugly_duckling::devices

--- a/components/devices/src/devices/GenericDevice.hpp
+++ b/components/devices/src/devices/GenericDevice.hpp
@@ -7,9 +7,9 @@
 
 #include <devices/DeviceDefinition.hpp>
 
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
-namespace farmhub::devices {
+namespace cornucopia::ugly_duckling::devices {
 
 class GenericDevice : public DeviceDefinition {
 public:
@@ -34,4 +34,4 @@ protected:
     }
 };
 
-}    // namespace farmhub::devices
+}    // namespace cornucopia::ugly_duckling::devices

--- a/components/devices/src/devices/UglyDucklingMk5.hpp
+++ b/components/devices/src/devices/UglyDucklingMk5.hpp
@@ -10,11 +10,11 @@
 
 #include <devices/DeviceDefinition.hpp>
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals::door;
-using namespace farmhub::peripherals::valve;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals::door;
+using namespace cornucopia::ugly_duckling::peripherals::valve;
 
-namespace farmhub::devices {
+namespace cornucopia::ugly_duckling::devices {
 
 class UglyDucklingMk5 : public DeviceDefinition {
 public:
@@ -80,4 +80,4 @@ private:
     DEFINE_PIN(GPIO_NUM_43, TXD0)
 };
 
-}    // namespace farmhub::devices
+}    // namespace cornucopia::ugly_duckling::devices

--- a/components/devices/src/devices/UglyDucklingMk6.hpp
+++ b/components/devices/src/devices/UglyDucklingMk6.hpp
@@ -14,11 +14,11 @@
 
 #include <devices/DeviceDefinition.hpp>
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals::door;
-using namespace farmhub::peripherals::valve;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals::door;
+using namespace cornucopia::ugly_duckling::peripherals::valve;
 
-namespace farmhub::devices {
+namespace cornucopia::ugly_duckling::devices {
 
 class UglyDucklingMk6Base : public DeviceDefinition {
 public:
@@ -132,4 +132,4 @@ protected:
     }
 };
 
-}    // namespace farmhub::devices
+}    // namespace cornucopia::ugly_duckling::devices

--- a/components/devices/src/devices/UglyDucklingMk7.hpp
+++ b/components/devices/src/devices/UglyDucklingMk7.hpp
@@ -11,11 +11,11 @@
 
 #include <devices/DeviceDefinition.hpp>
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals::door;
-using namespace farmhub::peripherals::valve;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals::door;
+using namespace cornucopia::ugly_duckling::peripherals::valve;
 
-namespace farmhub::devices {
+namespace cornucopia::ugly_duckling::devices {
 
 class UglyDucklingMk7 : public DeviceDefinition {
 public:
@@ -89,4 +89,4 @@ private:
     DEFINE_PIN(GPIO_NUM_48, IOA4, "A4")
 };
 
-}    // namespace farmhub::devices
+}    // namespace cornucopia::ugly_duckling::devices

--- a/components/devices/src/devices/UglyDucklingMk8.hpp
+++ b/components/devices/src/devices/UglyDucklingMk8.hpp
@@ -15,12 +15,12 @@
 
 #include <devices/DeviceDefinition.hpp>
 
-using namespace farmhub::kernel;
-using namespace farmhub::kernel::drivers;
-using namespace farmhub::peripherals::door;
-using namespace farmhub::peripherals::valve;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
+using namespace cornucopia::ugly_duckling::peripherals::door;
+using namespace cornucopia::ugly_duckling::peripherals::valve;
 
-namespace farmhub::devices {
+namespace cornucopia::ugly_duckling::devices {
 
 class UglyDucklingMk8Base : public DeviceDefinition {
 public:
@@ -149,4 +149,4 @@ private:
     std::shared_ptr<Ina219Driver> ina219;
 };
 
-}    // namespace farmhub::devices
+}    // namespace cornucopia::ugly_duckling::devices

--- a/components/functions/src/functions/Function.hpp
+++ b/components/functions/src/functions/Function.hpp
@@ -7,9 +7,9 @@
 
 #include <peripherals/Peripheral.hpp>
 
-using farmhub::peripherals::PeripheralManager;
+using cornucopia::ugly_duckling::peripherals::PeripheralManager;
 
-namespace farmhub::functions {
+namespace cornucopia::ugly_duckling::functions {
 
 struct FunctionServices {
     const std::shared_ptr<TelemetryPublisher> telemetryPublisher;
@@ -152,4 +152,4 @@ private:
     SettingsBasedManager<FunctionFactory> manager;
 };
 
-}    // namespace farmhub::functions
+}    // namespace cornucopia::ugly_duckling::functions

--- a/components/functions/src/functions/ScheduledTransitionLoop.hpp
+++ b/components/functions/src/functions/ScheduledTransitionLoop.hpp
@@ -15,11 +15,11 @@
 #include <scheduling/IScheduler.hpp>
 
 using namespace std::chrono_literals;
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals::api;
-using namespace farmhub::utils::scheduling;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals::api;
+using namespace cornucopia::ugly_duckling::utils::scheduling;
 
-namespace farmhub::functions {
+namespace cornucopia::ugly_duckling::functions {
 
 /**
  * @brief Common run loop for scheduled transitions of peripherals.
@@ -86,4 +86,4 @@ void runScheduledTransitionLoop(
     });
 }
 
-}    // namespace farmhub::functions
+}    // namespace cornucopia::ugly_duckling::functions

--- a/components/functions/src/functions/chicken_door/ChickenDoor.hpp
+++ b/components/functions/src/functions/chicken_door/ChickenDoor.hpp
@@ -15,10 +15,10 @@
 #include <scheduling/LightSensorScheduler.hpp>
 #include <scheduling/OverrideScheduler.hpp>
 
-using namespace farmhub::peripherals::api;
-using namespace farmhub::utils::scheduling;
+using namespace cornucopia::ugly_duckling::peripherals::api;
+using namespace cornucopia::ugly_duckling::utils::scheduling;
 
-namespace farmhub::functions::chicken_door {
+namespace cornucopia::ugly_duckling::functions::chicken_door {
 
 LOGGING_TAG(CHICKEN_DOOR, "chicken-door")
 
@@ -166,4 +166,4 @@ inline FunctionFactory makeFactory() {
         });
 }
 
-}    // namespace farmhub::functions::chicken_door
+}    // namespace cornucopia::ugly_duckling::functions::chicken_door

--- a/components/functions/src/functions/plot_controller/PlotController.hpp
+++ b/components/functions/src/functions/plot_controller/PlotController.hpp
@@ -20,12 +20,12 @@
 #include <utils/Chrono.hpp>
 
 using namespace std::chrono;
-using namespace farmhub::kernel::mqtt;
-using namespace farmhub::peripherals;
-using namespace farmhub::peripherals::api;
-using namespace farmhub::utils::scheduling;
+using namespace cornucopia::ugly_duckling::kernel::mqtt;
+using namespace cornucopia::ugly_duckling::peripherals;
+using namespace cornucopia::ugly_duckling::peripherals::api;
+using namespace cornucopia::ugly_duckling::utils::scheduling;
 
-namespace farmhub::functions::plot_controller {
+namespace cornucopia::ugly_duckling::functions::plot_controller {
 
 LOGGING_TAG(PLOT_CTRL, "plot-ctrl")
 
@@ -189,7 +189,7 @@ inline FunctionFactory makeFactory() {
                 std::make_shared<OverrideScheduler>(),
                 std::make_shared<TimeBasedScheduler>(),
                 std::make_shared<MoistureBasedScheduler<SteadyClock>>(
-                    farmhub::utils::scheduling::MoistureBasedSchedulerSettings {
+                    cornucopia::ugly_duckling::utils::scheduling::MoistureBasedSchedulerSettings {
                         .minVolume = moistureBasedSettings->minVolume.get(),
                         .maxVolume = moistureBasedSettings->maxVolume.get(),
                         .minGain = moistureBasedSettings->minGain.get(),
@@ -213,4 +213,4 @@ inline FunctionFactory makeFactory() {
         });
 }
 
-}    // namespace farmhub::functions::plot_controller
+}    // namespace cornucopia::ugly_duckling::functions::plot_controller

--- a/components/kernel/src/BatteryManager.hpp
+++ b/components/kernel/src/BatteryManager.hpp
@@ -11,9 +11,9 @@
 #include <drivers/BatteryDriver.hpp>
 #include <utility>
 
-using namespace farmhub::kernel::drivers;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 /**
  * @brief Time to wait between battery checks.
@@ -99,4 +99,4 @@ private:
     static constexpr auto LOW_BATTERY_SHUTDOWN_TIMEOUT = 10s;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Concurrent.hpp
+++ b/components/kernel/src/Concurrent.hpp
@@ -12,7 +12,7 @@
 
 using namespace std::chrono;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 class BaseQueue {
 protected:
@@ -306,4 +306,4 @@ private:
     MutexBase& mutex;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Configuration.hpp
+++ b/components/kernel/src/Configuration.hpp
@@ -13,7 +13,7 @@
 using std::ref;
 using std::reference_wrapper;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 class ConfigurationException
     : public std::exception {
@@ -280,7 +280,7 @@ private:
     std::vector<T> entries;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel
 
 namespace ArduinoJson {
 
@@ -306,7 +306,7 @@ struct Converter<D> {
     }
 };
 
-using farmhub::kernel::JsonAsString;
+using cornucopia::ugly_duckling::kernel::JsonAsString;
 
 template <>
 struct Converter<JsonAsString> {

--- a/components/kernel/src/Console.hpp
+++ b/components/kernel/src/Console.hpp
@@ -4,18 +4,18 @@
 #include <Log.hpp>
 #include <utility>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
-#define FARMHUB_LOG_COLOR_BLACK "30"
-#define FARMHUB_LOG_COLOR_RED "31"
-#define FARMHUB_LOG_COLOR_GREEN "32"
-#define FARMHUB_LOG_COLOR_BROWN "33"
-#define FARMHUB_LOG_COLOR_BLUE "34"
-#define FARMHUB_LOG_COLOR_PURPLE "35"
-#define FARMHUB_LOG_COLOR_CYAN "36"
-#define FARMHUB_LOG_COLOR(COLOR) "\033[0;" COLOR "m"
-#define FARMHUB_LOG_BOLD(COLOR) "\033[1;" COLOR "m"
-#define FARMHUB_LOG_RESET_COLOR "\033[0m"
+#define UD_LOG_COLOR_BLACK "30"
+#define UD_LOG_COLOR_RED "31"
+#define UD_LOG_COLOR_GREEN "32"
+#define UD_LOG_COLOR_BROWN "33"
+#define UD_LOG_COLOR_BLUE "34"
+#define UD_LOG_COLOR_PURPLE "35"
+#define UD_LOG_COLOR_CYAN "36"
+#define UD_LOG_COLOR(COLOR) "\033[0;" COLOR "m"
+#define UD_LOG_BOLD(COLOR) "\033[1;" COLOR "m"
+#define UD_LOG_RESET_COLOR "\033[0m"
 
 class ConsoleProvider {
 public:
@@ -61,24 +61,24 @@ private:
         }
 
         int count = 0;
-#ifdef FARMHUB_DEBUG
+#ifdef UD_DEBUG
         // Erase the current line
         count += printf("\033[1G\033[0K");
         switch (level) {
             case Level::Error:
-                count += printf(FARMHUB_LOG_COLOR(FARMHUB_LOG_COLOR_RED));
+                count += printf(UD_LOG_COLOR(UD_LOG_COLOR_RED));
                 break;
             case Level::Warning:
-                count += printf(FARMHUB_LOG_COLOR(FARMHUB_LOG_COLOR_BROWN));
+                count += printf(UD_LOG_COLOR(UD_LOG_COLOR_BROWN));
                 break;
             case Level::Info:
-                count += printf(FARMHUB_LOG_COLOR(FARMHUB_LOG_COLOR_GREEN));
+                count += printf(UD_LOG_COLOR(UD_LOG_COLOR_GREEN));
                 break;
             case Level::Debug:
-                count += printf(FARMHUB_LOG_COLOR(FARMHUB_LOG_COLOR_CYAN));
+                count += printf(UD_LOG_COLOR(UD_LOG_COLOR_CYAN));
                 break;
             case Level::Verbose:
-                count += printf(FARMHUB_LOG_COLOR(FARMHUB_LOG_COLOR_BLUE));
+                count += printf(UD_LOG_COLOR(UD_LOG_COLOR_BLUE));
                 break;
             default:
                 break;
@@ -87,12 +87,12 @@ private:
 
         count += printf("%s", message.c_str());
 
-#ifdef FARMHUB_DEBUG
+#ifdef UD_DEBUG
         switch (level) {
             case Level::Error:
             case Level::Warning:
             case Level::Info:
-                count += printf(FARMHUB_LOG_RESET_COLOR);
+                count += printf(UD_LOG_RESET_COLOR);
                 break;
             default:
                 break;
@@ -164,4 +164,4 @@ char ConsoleProvider::buffer[BUFFER_SIZE];
 std::mutex ConsoleProvider::partialMessageMutex;
 std::string ConsoleProvider::partialMessage;
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/CrashManager.hpp
+++ b/components/kernel/src/CrashManager.hpp
@@ -8,7 +8,7 @@
 #include <NvsStore.hpp>
 #include <Strings.hpp>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 LOGGING_TAG(CRASH, "crash")
 
@@ -34,7 +34,7 @@ public:
                 break;
             }
         }
-        nvs.set("version", farmhubVersion);
+        nvs.set("version", firmwareVersion);
     }
 
 private:
@@ -267,4 +267,4 @@ private:
     }
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/DebugConsole.hpp
+++ b/components/kernel/src/DebugConsole.hpp
@@ -11,11 +11,11 @@
 
 using namespace std::chrono;
 
-using namespace farmhub::kernel::drivers;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
-#ifdef FARMHUB_DEBUG
+#ifdef UD_DEBUG
 class DebugConsole {
 public:
     DebugConsole(const std::shared_ptr<BatteryManager>& battery, const std::shared_ptr<WiFiDriver>& wifi)
@@ -37,7 +37,7 @@ private:
         counter = (counter + 1) % spinnerLength;
         status.clear();
         status += "[" + std::string(1, spinner[counter]) + "] ";
-        status += "\033[33m" + std::string(farmhubVersion) + "\033[0m";
+        status += "\033[33m" + std::string(firmwareVersion) + "\033[0m";
         status += ", uptime: \033[33m" + toStringWithPrecision(static_cast<double>(uptime.count()) / 1000.0, 1) + "\033[0m s";
         status += ", WIFI: " + std::string(wifiStatus());
         status += ", RTC \033[33m" + std::string(RtcDriver::isTimeSet() ? "OK" : "UNSYNCED") + "\033[0m";
@@ -108,4 +108,4 @@ private:
 };
 #endif
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/EspException.hpp
+++ b/components/kernel/src/EspException.hpp
@@ -3,7 +3,7 @@
 #include <esp_err.h>
 #include <exception>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 class EspException
     : public std::runtime_error {
@@ -21,4 +21,4 @@ public:
         }                              \
     } while (0)
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/HttpUpdate.hpp
+++ b/components/kernel/src/HttpUpdate.hpp
@@ -14,7 +14,7 @@
 #include <drivers/WiFiDriver.hpp>
 #include <utility>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 LOGGING_TAG(UPDATE, "update")
 
@@ -61,7 +61,7 @@ private:
 
     void performPendingHttpUpdate(const std::string& url, const std::shared_ptr<WiFiDriver>& wifi) {
         LOGTI(UPDATE, "Updating from version %s via URL %s",
-            farmhubVersion, url.c_str());
+            firmwareVersion, url.c_str());
 
         LOGTD(UPDATE, "Waiting for network...");
         if (!wifi->getNetworkReady().awaitSet(15s)) {
@@ -146,4 +146,4 @@ private:
     static constexpr const size_t DOWNLOAD_NOTIFICATION_BATCH = 128 * 1024;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/I2CManager.hpp
+++ b/components/kernel/src/I2CManager.hpp
@@ -13,9 +13,9 @@
 #include <Strings.hpp>
 #include <utility>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
-using farmhub::kernel::PinPtr;
+using cornucopia::ugly_duckling::kernel::PinPtr;
 
 using GpioPair = std::pair<PinPtr, PinPtr>;
 
@@ -186,4 +186,4 @@ private:
     std::vector<std::shared_ptr<I2CBus>> buses;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/KernelStatus.hpp
+++ b/components/kernel/src/KernelStatus.hpp
@@ -23,10 +23,10 @@
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
-using namespace farmhub::kernel::drivers;
-using namespace farmhub::kernel::mqtt;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
+using namespace cornucopia::ugly_duckling::kernel::mqtt;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 static RTC_DATA_ATTR int bootCount = 0;
@@ -126,4 +126,4 @@ private:
     }
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Log.hpp
+++ b/components/kernel/src/Log.hpp
@@ -6,7 +6,7 @@
 
 #include <esp_log.h>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 enum class Level : uint8_t {
     None = 0,
@@ -23,16 +23,16 @@ struct LogRecord {
     const std::string message;
 };
 
-#ifndef FARMHUB_LOG_LEVEL
-#ifdef FARMHUB_DEBUG
-#define FARMHUB_LOG_LEVEL ESP_LOG_DEBUG
+#ifndef UD_LOG_LEVEL
+#ifdef UD_DEBUG
+#define UD_LOG_LEVEL ESP_LOG_DEBUG
 #else
-#define FARMHUB_LOG_LEVEL ESP_LOG_INFO
+#define UD_LOG_LEVEL ESP_LOG_INFO
 #endif
 #endif
 
-#ifndef FARMHUB_LOG_VERBOSE
-#define FARMHUB_LOG_VERBOSE ""
+#ifndef UD_LOG_VERBOSE
+#define UD_LOG_VERBOSE ""
 #endif
 
 // helper: check if substring is in comma-separated list
@@ -53,11 +53,11 @@ inline bool loggingTagInList(const char* tag, const char* list) {
 
 // LOGGING_TAG(varName, "tagname")
 #define LOGGING_TAG(varName, name)                              \
-    inline constexpr const char* varName = "farmhub:" name;    \
+    inline constexpr const char* varName = "ud:" name;    \
     struct varName##_LoggerInit {                              \
         varName##_LoggerInit() {                               \
-            esp_log_level_t lvl = FARMHUB_LOG_LEVEL;           \
-            if (loggingTagInList(name, FARMHUB_LOG_VERBOSE)) { \
+            esp_log_level_t lvl = UD_LOG_LEVEL;           \
+            if (loggingTagInList(name, UD_LOG_VERBOSE)) { \
                 lvl = ESP_LOG_VERBOSE;                         \
             }                                                  \
             esp_log_level_set(varName, lvl);                   \
@@ -79,4 +79,4 @@ LOGGING_TAG(GLOBAL, "global")
 #define LOGD(format, ...) LOGTD(GLOBAL, format, ##__VA_ARGS__)
 #define LOGV(format, ...) LOGTV(GLOBAL, format, ##__VA_ARGS__)
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/LogJson.hpp
+++ b/components/kernel/src/LogJson.hpp
@@ -5,7 +5,7 @@
 
 namespace ArduinoJson {
 
-using farmhub::kernel::Level;
+using cornucopia::ugly_duckling::kernel::Level;
 
 template <>
 struct Converter<Level> {

--- a/components/kernel/src/MacAddress.hpp
+++ b/components/kernel/src/MacAddress.hpp
@@ -5,7 +5,7 @@
 
 #include <esp_mac.h>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 constexpr size_t MAC_ADDRESS_LENGTH = 6;
 
@@ -40,4 +40,4 @@ static bool macAddressHasPrefix(Bytes... bytes) {
     return std::equal(prefix.begin(), prefix.end(), mac.begin());
 }
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Manager.hpp
+++ b/components/kernel/src/Manager.hpp
@@ -11,7 +11,7 @@
 #include <Concurrent.hpp>
 #include <Configuration.hpp>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 // Forward declarations and common types
 struct ShutdownParameters {
@@ -212,4 +212,4 @@ private:
     };
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/MovingAverage.hpp
+++ b/components/kernel/src/MovingAverage.hpp
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 template <typename M, typename T = M>
 requires std::is_arithmetic_v<M> && std::is_arithmetic_v<T>
@@ -42,4 +42,4 @@ private:
     T average;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Named.hpp
+++ b/components/kernel/src/Named.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 class Named {
 protected:
@@ -12,4 +12,4 @@ public:
     const std::string name;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/NvsConfiguration.hpp
+++ b/components/kernel/src/NvsConfiguration.hpp
@@ -8,7 +8,7 @@
 #include "Configuration.hpp"
 #include "NvsStore.hpp"
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 /**
  * @brief Loads a ConfigurationSection from NVS, and persists updates back to NVS.
@@ -67,4 +67,4 @@ std::shared_ptr<TConfiguration> loadConfigFromNvs(const std::shared_ptr<NvsStore
     return config;
 }
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/NvsStore.hpp
+++ b/components/kernel/src/NvsStore.hpp
@@ -9,7 +9,7 @@
 
 #include <ArduinoJson.h>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 LOGGING_TAG(NVS, "nvs")
 
@@ -196,4 +196,4 @@ private:
     const std::string ns;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Overloaded.hpp
+++ b/components/kernel/src/Overloaded.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 template <typename... Ts>
 struct overloaded : Ts... {
     using Ts::operator()...;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/PcntManager.hpp
+++ b/components/kernel/src/PcntManager.hpp
@@ -7,7 +7,7 @@
 #include <EspException.hpp>
 #include <utility>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 LOGGING_TAG(PCNT, "pcnt")
 
@@ -93,4 +93,4 @@ public:
     }
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Pin.cpp
+++ b/components/kernel/src/Pin.cpp
@@ -7,7 +7,7 @@
 #include <esp_adc/adc_oneshot.h>
 #include <soc/gpio_num.h>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 std::map<std::string, PinPtr> Pin::BY_NAME;
 
@@ -15,4 +15,4 @@ std::map<std::string, InternalPinPtr> InternalPin::INTERNAL_BY_NAME;
 std::map<gpio_num_t, InternalPinPtr> InternalPin::INTERNAL_BY_GPIO;
 std::vector<adc_oneshot_unit_handle_t> AnalogPin::ANALOG_UNITS { 2 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Pin.hpp
+++ b/components/kernel/src/Pin.hpp
@@ -17,7 +17,7 @@
 #include <EspException.hpp>
 #include <Log.hpp>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 class Pin;
 using PinPtr = std::shared_ptr<Pin>;
@@ -282,14 +282,14 @@ private:
 };
 
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel
 
 namespace ArduinoJson {
 
-using farmhub::kernel::InternalPin;
-using farmhub::kernel::InternalPinPtr;
-using farmhub::kernel::Pin;
-using farmhub::kernel::PinPtr;
+using cornucopia::ugly_duckling::kernel::InternalPin;
+using cornucopia::ugly_duckling::kernel::InternalPinPtr;
+using cornucopia::ugly_duckling::kernel::Pin;
+using cornucopia::ugly_duckling::kernel::PinPtr;
 
 template <>
 struct Converter<PinPtr> {

--- a/components/kernel/src/PowerManager.cpp
+++ b/components/kernel/src/PowerManager.cpp
@@ -2,8 +2,8 @@
 
 #include <esp_pm.h>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 PowerManagementLock PowerManager::noLightSleep("no-light-sleep", ESP_PM_NO_LIGHT_SLEEP);
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/PowerManager.hpp
+++ b/components/kernel/src/PowerManager.hpp
@@ -20,7 +20,7 @@
 
 using namespace std::chrono;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 LOGGING_TAG(PM, "pm")
 
@@ -132,7 +132,7 @@ public:
 private:
     static bool shouldSleepWhenIdle(bool requestedSleepWhenIdle) {
         if (requestedSleepWhenIdle) {
-#if FARMHUB_DEBUG
+#if UD_DEBUG
             LOGTI(PM, "Light sleep is disabled in debug mode");
             return false;
 #elif not(CONFIG_PM_ENABLE)
@@ -159,4 +159,4 @@ private:
 };
 
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/PulseCounter.cpp
+++ b/components/kernel/src/PulseCounter.cpp
@@ -21,7 +21,7 @@
 #if defined(CONFIG_ULP_COPROC_TYPE_RISCV)
 #include <ulp_common.h>
 #include <ulp_riscv.h>
-#ifdef FARMHUB_DEBUG
+#ifdef UD_DEBUG
 #include <bits/chrono.h>
 #include <soc/rtc_cntl_reg.h>
 #include <soc/sens_reg.h>
@@ -48,7 +48,7 @@ extern const uint8_t ulp_pulse_counter_bin_end[]   asm("_binary_ulp_pulse_counte
 
 using namespace std::chrono;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 // ============================================================================
 // UlpPulseCounter — RTC/LP GPIO path, no per-pulse CPU wakeups
@@ -164,7 +164,7 @@ void PulseCounterManager::start() {
 
 #if defined(CONFIG_ULP_COPROC_TYPE_RISCV)
     ESP_ERROR_THROW(ulp_riscv_run());
-#ifdef FARMHUB_DEBUG
+#ifdef UD_DEBUG
     // Give the ULP a moment to run and halt; then check registers to see if it actually executed.
     Task::delay(100ms);
     // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast,performance-no-int-to-ptr) -- ESP-IDF REG_READ macro
@@ -263,4 +263,4 @@ std::shared_ptr<PulseCounter> PulseCounterManager::createGpio(const PulseCounter
     return counter;
 }
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/PulseCounter.hpp
+++ b/components/kernel/src/PulseCounter.hpp
@@ -15,7 +15,7 @@
 
 using namespace std::chrono;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 LOGGING_TAG(PULSE, "pulse")
 
@@ -218,4 +218,4 @@ private:
     std::shared_ptr<PulseCounter> createGpio(const PulseCounterConfig& config);
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/PwmManager.hpp
+++ b/components/kernel/src/PwmManager.hpp
@@ -4,7 +4,7 @@
 
 #include <driver/ledc.h>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 // TODO Figure out what to do with low/high speed modes
 //      See https://docs.espressif.com/projects/esp-idf/en/release-v4.2/esp32/api-reference/peripherals/ledc.html#ledc-high-and-low-speed-mode
@@ -131,4 +131,4 @@ private:
     std::list<PwmPin> pins;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/ShutdownManager.hpp
+++ b/components/kernel/src/ShutdownManager.hpp
@@ -5,7 +5,7 @@
 
 #include <Task.hpp>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 class ShutdownManager {
 public:
@@ -28,4 +28,4 @@ private:
     std::vector<std::function<void()>> shutdownListeners;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/State.cpp
+++ b/components/kernel/src/State.cpp
@@ -1,7 +1,7 @@
 #include "State.hpp"
 #include "freertos/idf_additions.h"
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 bool StateSource::setFromISR() const {
     return hasAllBits(setBitsFromISR(eventBits | STATE_CHANGE_BIT_MASK));
@@ -13,4 +13,4 @@ bool StateSource::clearFromISR() const {
     return cleared;
 }
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/State.hpp
+++ b/components/kernel/src/State.hpp
@@ -9,7 +9,7 @@
 
 using namespace std::chrono;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 // 0th bit reserved to indicate that a state has changed
 static constexpr int STATE_CHANGE_BIT_MASK = (1 << 0);
@@ -104,4 +104,4 @@ private:
     }
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/StateManager.hpp
+++ b/components/kernel/src/StateManager.hpp
@@ -4,7 +4,7 @@
 
 #include <State.hpp>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 /**
  * @brief Handles a group of states and allows waiting for the next state to change.
@@ -61,4 +61,4 @@ private:
     int nextEventBit = 1;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Strings.hpp
+++ b/components/kernel/src/Strings.hpp
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <string>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 static constexpr const char* DIGITS = "0123456789abcdef";
 
@@ -29,4 +29,4 @@ std::string toStringWithPrecision(double value, int precision) {
     return { buffer };
 }
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Task.hpp
+++ b/components/kernel/src/Task.hpp
@@ -12,7 +12,7 @@
 
 using namespace std::chrono;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 static const unsigned int DEFAULT_PRIORITY = 1;
 
@@ -174,4 +174,4 @@ private:
     TickType_t lastWakeTime { xTaskGetTickCount() };
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Telemetry.hpp
+++ b/components/kernel/src/Telemetry.hpp
@@ -9,7 +9,7 @@
 #include <Concurrent.hpp>
 #include <Log.hpp>
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 class TelemetryCollector {
 public:
@@ -57,4 +57,4 @@ private:
     std::shared_ptr<CopyQueue<bool>> telemetryPublishQueue;
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Time.hpp
+++ b/components/kernel/src/Time.hpp
@@ -4,7 +4,7 @@
 
 using namespace std::chrono_literals;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 using ticks = std::chrono::duration<uint32_t, std::ratio<1, configTICK_RATE_HZ>>;
 
@@ -18,4 +18,4 @@ inline static ticks clampTicks(std::chrono::milliseconds duration) {
     return std::chrono::duration_cast<ticks>(duration);
 }
 
-} // namespace farmhub::kernel
+} // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Watchdog.hpp
+++ b/components/kernel/src/Watchdog.hpp
@@ -12,7 +12,7 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-namespace farmhub::kernel {
+namespace cornucopia::ugly_duckling::kernel {
 
 enum class WatchdogState : uint8_t {
     Started,
@@ -78,4 +78,4 @@ private:
     esp_timer_handle_t timer {};
 };
 
-}    // namespace farmhub::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/drivers/BatteryDriver.hpp
+++ b/components/kernel/src/drivers/BatteryDriver.hpp
@@ -7,9 +7,9 @@
 #include <Telemetry.hpp>
 #include <utility>
 
-using farmhub::kernel::PinPtr;
+using cornucopia::ugly_duckling::kernel::PinPtr;
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 struct BatteryParameters {
     /**
@@ -104,4 +104,4 @@ private:
     const double voltageDividerRatio;
 };
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/Bq27220Driver.hpp
+++ b/components/kernel/src/drivers/Bq27220Driver.hpp
@@ -10,9 +10,9 @@
 #include <I2CManager.hpp>
 #include <drivers/BatteryDriver.hpp>
 
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 // Default Gauging Parameter
 static const parameter_cedv_t default_cedv = {
@@ -127,4 +127,4 @@ private:
     bq27220_handle_t gauge = nullptr;
 };
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/Drv8801Driver.hpp
+++ b/components/kernel/src/drivers/Drv8801Driver.hpp
@@ -11,7 +11,7 @@
 
 using namespace std::chrono;
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 /**
  * @brief Texas Instruments DRV8801 motor driver.
@@ -108,4 +108,4 @@ private:
     std::atomic<bool> sleeping { false };
 };
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/Drv8833Driver.hpp
+++ b/components/kernel/src/drivers/Drv8833Driver.hpp
@@ -12,7 +12,7 @@
 
 using namespace std::chrono;
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 /**
  * @brief Texas Instruments DRV8833 dual motor driver.
@@ -165,4 +165,4 @@ private:
     std::atomic<bool> sleeping { false };
 };
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/Drv8848Driver.hpp
+++ b/components/kernel/src/drivers/Drv8848Driver.hpp
@@ -2,7 +2,7 @@
 
 #include "Drv8833Driver.hpp"
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 /**
  * @brief Texas Instruments DRV8848 dual motor driver.
@@ -13,4 +13,4 @@ namespace farmhub::kernel::drivers {
  */
 using Drv8848Driver = Drv8833Driver;
 
-} // namespace farmhub::kernel::drivers
+} // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/Drv8874Driver.hpp
+++ b/components/kernel/src/drivers/Drv8874Driver.hpp
@@ -11,7 +11,7 @@
 
 using namespace std::chrono;
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 /**
  * @brief Texas Instruments DRV8874 motor driver.
@@ -103,4 +103,4 @@ private:
     std::atomic<bool> sleeping { false };
 };
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/Ina219Driver.hpp
+++ b/components/kernel/src/drivers/Ina219Driver.hpp
@@ -4,9 +4,9 @@
 
 #include <I2CManager.hpp>
 
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 struct Ina219Parameters {
     ina219_bus_voltage_range_t uRange;
@@ -103,4 +103,4 @@ private:
     bool enabled;
 };
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/LedDriver.hpp
+++ b/components/kernel/src/drivers/LedDriver.hpp
@@ -10,9 +10,9 @@
 
 using namespace std::chrono;
 
-using farmhub::kernel::PinPtr;
+using cornucopia::ugly_duckling::kernel::PinPtr;
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 class LedDriver {
 public:
@@ -93,4 +93,4 @@ private:
     std::atomic<bool> ledState;
 };
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/MotorDriver.cpp
+++ b/components/kernel/src/drivers/MotorDriver.cpp
@@ -1,6 +1,6 @@
 #include "MotorDriver.hpp"
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 MotorPhase operator-(MotorPhase phase) {
     return phase == MotorPhase::Forward
@@ -8,4 +8,4 @@ MotorPhase operator-(MotorPhase phase) {
         : MotorPhase::Forward;
 }
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/MotorDriver.hpp
+++ b/components/kernel/src/drivers/MotorDriver.hpp
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 enum class MotorPhase : int8_t {
     Forward = 1,
@@ -22,4 +22,4 @@ public:
     virtual void drive(MotorPhase phase, double duty) = 0;
 };
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/RtcDriver.hpp
+++ b/components/kernel/src/drivers/RtcDriver.hpp
@@ -15,7 +15,7 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 LOGGING_TAG(RTC, "rtc")
 
@@ -116,4 +116,4 @@ private:
     StateSource& rtcInSync;
 };
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/SwitchManager.hpp
+++ b/components/kernel/src/drivers/SwitchManager.hpp
@@ -13,9 +13,9 @@
 
 using namespace std::chrono;
 
-using farmhub::kernel::PinPtr;
+using cornucopia::ugly_duckling::kernel::PinPtr;
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 LOGGING_TAG(SWITCH, "switch")
 
@@ -213,4 +213,4 @@ static void IRAM_ATTR handleSwitchInterrupt(void* arg) {
     });
 }
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/WiFiDriver.hpp
+++ b/components/kernel/src/drivers/WiFiDriver.hpp
@@ -15,9 +15,9 @@
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
-namespace farmhub::kernel::drivers {
+namespace cornucopia::ugly_duckling::kernel::drivers {
 
 LOGGING_TAG(WIFI, "wifi")
 
@@ -424,4 +424,4 @@ private:
     std::atomic<int> disconnectCount { 0 };
 };
 
-}    // namespace farmhub::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/mqtt/MqttDriver.hpp
+++ b/components/kernel/src/mqtt/MqttDriver.hpp
@@ -20,10 +20,10 @@
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
-using namespace farmhub::kernel;
-using namespace farmhub::kernel::drivers;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
 
-namespace farmhub::kernel::mqtt {
+namespace cornucopia::ugly_duckling::kernel::mqtt {
 
 LOGGING_TAG(MQTT, "mqtt")
 
@@ -719,4 +719,4 @@ private:
     friend class MqttRoot;
 };
 
-}    // namespace farmhub::kernel::mqtt
+}    // namespace cornucopia::ugly_duckling::kernel::mqtt

--- a/components/kernel/src/mqtt/MqttLog.hpp
+++ b/components/kernel/src/mqtt/MqttLog.hpp
@@ -4,7 +4,7 @@
 #include <Task.hpp>
 #include <mqtt/MqttRoot.hpp>
 
-namespace farmhub::kernel::mqtt {
+namespace cornucopia::ugly_duckling::kernel::mqtt {
 
 class MqttLog {
 public:
@@ -34,4 +34,4 @@ public:
     }
 };
 
-}    // namespace farmhub::kernel::mqtt
+}    // namespace cornucopia::ugly_duckling::kernel::mqtt

--- a/components/kernel/src/mqtt/MqttRoot.hpp
+++ b/components/kernel/src/mqtt/MqttRoot.hpp
@@ -7,7 +7,7 @@
 #include <mqtt/MqttDriver.hpp>
 #include <utility>
 
-namespace farmhub::kernel::mqtt {
+namespace cornucopia::ugly_duckling::kernel::mqtt {
 
 class MqttRoot {
 public:
@@ -79,4 +79,4 @@ private:
     std::unordered_map<std::string, CommandHandler> commandHandlers;
 };
 
-}    // namespace farmhub::kernel::mqtt
+}    // namespace cornucopia::ugly_duckling::kernel::mqtt

--- a/components/kernel/src/mqtt/PendingMessages.hpp
+++ b/components/kernel/src/mqtt/PendingMessages.hpp
@@ -5,7 +5,7 @@
 #include <Concurrent.hpp>
 #include <Task.hpp>
 
-namespace farmhub::kernel::mqtt {
+namespace cornucopia::ugly_duckling::kernel::mqtt {
 
 enum class PublishStatus : uint8_t {
     TimeOut = 0,
@@ -91,4 +91,4 @@ private:
     std::unordered_map<int, TaskHandle_t> messages;
 };
 
-}    // namespace farmhub::kernel::mqtt
+}    // namespace cornucopia::ugly_duckling::kernel::mqtt

--- a/components/kernel/test/ConfigurationTest.cpp
+++ b/components/kernel/test/ConfigurationTest.cpp
@@ -9,7 +9,7 @@
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
 struct TestNestedConfig : ConfigurationSection {
     Property<int> intValue { this, "intValue" };

--- a/components/kernel/test/MovingAverageTest.cpp
+++ b/components/kernel/test/MovingAverageTest.cpp
@@ -2,7 +2,7 @@
 
 #include <MovingAverage.hpp>
 
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
 TEST_CASE("empty instance returns zero") {
     MovingAverage<double> ma(3);

--- a/components/kernel/test/Strings.test.cpp
+++ b/components/kernel/test/Strings.test.cpp
@@ -2,9 +2,11 @@
 
 #include <Strings.hpp>
 
+using namespace cornucopia::ugly_duckling::kernel;
+
 TEST_CASE("toHexString") {
-    REQUIRE(cornucopia::ugly_duckling::kernel::toHexString(0) == "0x0");
-    REQUIRE(cornucopia::ugly_duckling::kernel::toHexString(1) == "0x1");
-    REQUIRE(cornucopia::ugly_duckling::kernel::toHexString(15) == "0xf");
-    REQUIRE(cornucopia::ugly_duckling::kernel::toHexString(0x123456ab) == "0x123456ab");
+    REQUIRE(toHexString(0) == "0x0");
+    REQUIRE(toHexString(1) == "0x1");
+    REQUIRE(toHexString(15) == "0xf");
+    REQUIRE(toHexString(0x123456ab) == "0x123456ab");
 }

--- a/components/kernel/test/Strings.test.cpp
+++ b/components/kernel/test/Strings.test.cpp
@@ -3,8 +3,8 @@
 #include <Strings.hpp>
 
 TEST_CASE("toHexString") {
-    REQUIRE(farmhub::kernel::toHexString(0) == "0x0");
-    REQUIRE(farmhub::kernel::toHexString(1) == "0x1");
-    REQUIRE(farmhub::kernel::toHexString(15) == "0xf");
-    REQUIRE(farmhub::kernel::toHexString(0x123456ab) == "0x123456ab");
+    REQUIRE(cornucopia::ugly_duckling::kernel::toHexString(0) == "0x0");
+    REQUIRE(cornucopia::ugly_duckling::kernel::toHexString(1) == "0x1");
+    REQUIRE(cornucopia::ugly_duckling::kernel::toHexString(15) == "0xf");
+    REQUIRE(cornucopia::ugly_duckling::kernel::toHexString(0x123456ab) == "0x123456ab");
 }

--- a/components/peripherals-api/src/peripherals/api/IDoor.hpp
+++ b/components/peripherals-api/src/peripherals/api/IDoor.hpp
@@ -8,7 +8,7 @@
 #include "IPeripheral.hpp"
 #include "TargetState.hpp"
 
-namespace farmhub::peripherals::api {
+namespace cornucopia::ugly_duckling::peripherals::api {
 
 enum class DoorState : int8_t {
     Closed = -1,
@@ -48,11 +48,11 @@ struct IDoor : virtual IPeripheral {
     virtual std::optional<DoorState> getState() = 0;
 };
 
-}    // namespace farmhub::peripherals::api
+}    // namespace cornucopia::ugly_duckling::peripherals::api
 
 namespace ArduinoJson {
 
-using farmhub::peripherals::api::DoorState;
+using cornucopia::ugly_duckling::peripherals::api::DoorState;
 
 template <>
 struct Converter<DoorState> {

--- a/components/peripherals-api/src/peripherals/api/IFlowMeter.hpp
+++ b/components/peripherals-api/src/peripherals/api/IFlowMeter.hpp
@@ -3,10 +3,10 @@
 #include "IPeripheral.hpp"
 #include "Units.hpp"
 
-namespace farmhub::peripherals::api {
+namespace cornucopia::ugly_duckling::peripherals::api {
 
 struct IFlowMeter : virtual IPeripheral {
     virtual Liters getVolume() = 0;
 };
 
-}    // namespace farmhub::peripherals::api
+}    // namespace cornucopia::ugly_duckling::peripherals::api

--- a/components/peripherals-api/src/peripherals/api/ILightSensor.hpp
+++ b/components/peripherals-api/src/peripherals/api/ILightSensor.hpp
@@ -3,10 +3,10 @@
 #include "IPeripheral.hpp"
 #include "Units.hpp"
 
-namespace farmhub::peripherals::api {
+namespace cornucopia::ugly_duckling::peripherals::api {
 
 struct ILightSensor : virtual IPeripheral {
     virtual Lux getLightLevel() = 0;
 };
 
-}    // namespace farmhub::peripherals::api
+}    // namespace cornucopia::ugly_duckling::peripherals::api

--- a/components/peripherals-api/src/peripherals/api/IPeripheral.hpp
+++ b/components/peripherals-api/src/peripherals/api/IPeripheral.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-namespace farmhub::peripherals::api {
+namespace cornucopia::ugly_duckling::peripherals::api {
 
 struct IPeripheral {
     virtual ~IPeripheral() = default;
@@ -10,4 +10,4 @@ struct IPeripheral {
     virtual const std::string& getName() const = 0;
 };
 
-} // namespace farmhub::peripherals::api
+} // namespace cornucopia::ugly_duckling::peripherals::api

--- a/components/peripherals-api/src/peripherals/api/ISoilMoistureSensor.hpp
+++ b/components/peripherals-api/src/peripherals/api/ISoilMoistureSensor.hpp
@@ -3,10 +3,10 @@
 #include "IPeripheral.hpp"
 #include "Units.hpp"
 
-namespace farmhub::peripherals::api {
+namespace cornucopia::ugly_duckling::peripherals::api {
 
 struct ISoilMoistureSensor : virtual IPeripheral {
     virtual Percent getMoisture() = 0;    // Returns a raw moisture percentage reading
 };
 
-}    // namespace farmhub::peripherals::api
+}    // namespace cornucopia::ugly_duckling::peripherals::api

--- a/components/peripherals-api/src/peripherals/api/ITemperatureSensor.hpp
+++ b/components/peripherals-api/src/peripherals/api/ITemperatureSensor.hpp
@@ -3,10 +3,10 @@
 #include "IPeripheral.hpp"
 #include "Units.hpp"
 
-namespace farmhub::peripherals::api {
+namespace cornucopia::ugly_duckling::peripherals::api {
 
 struct ITemperatureSensor : virtual IPeripheral {
     virtual Celsius getTemperature() = 0;  // Returns a raw temperature reading
 };
 
-}    // namespace farmhub::peripherals::api
+}    // namespace cornucopia::ugly_duckling::peripherals::api

--- a/components/peripherals-api/src/peripherals/api/IValve.hpp
+++ b/components/peripherals-api/src/peripherals/api/IValve.hpp
@@ -63,12 +63,12 @@ struct Converter<ValveState> {
         }
     }
 
-    static cornucopia::ugly_duckling::peripherals::api::ValveState fromJson(JsonVariantConst src) {
+    static ValveState fromJson(JsonVariantConst src) {
         auto* str = src.as<const char*>();
         if (strcmp(str, "Closed") == 0) {
-            return cornucopia::ugly_duckling::peripherals::api::ValveState::Closed;
+            return ValveState::Closed;
         } else {
-            return cornucopia::ugly_duckling::peripherals::api::ValveState::Open;
+            return ValveState::Open;
         }
     }
 

--- a/components/peripherals-api/src/peripherals/api/IValve.hpp
+++ b/components/peripherals-api/src/peripherals/api/IValve.hpp
@@ -5,7 +5,7 @@
 #include "IPeripheral.hpp"
 #include "TargetState.hpp"
 
-namespace farmhub::peripherals::api {
+namespace cornucopia::ugly_duckling::peripherals::api {
 
 enum class ValveState : int8_t {
     Closed = -1,
@@ -44,11 +44,11 @@ struct IValve : virtual IPeripheral {
     virtual std::optional<ValveState> getState() const = 0;
 };
 
-}    // namespace farmhub::peripherals::api
+}    // namespace cornucopia::ugly_duckling::peripherals::api
 
 namespace ArduinoJson {
 
-using farmhub::peripherals::api::ValveState;
+using cornucopia::ugly_duckling::peripherals::api::ValveState;
 
 template <>
 struct Converter<ValveState> {
@@ -63,12 +63,12 @@ struct Converter<ValveState> {
         }
     }
 
-    static farmhub::peripherals::api::ValveState fromJson(JsonVariantConst src) {
+    static cornucopia::ugly_duckling::peripherals::api::ValveState fromJson(JsonVariantConst src) {
         auto* str = src.as<const char*>();
         if (strcmp(str, "Closed") == 0) {
-            return farmhub::peripherals::api::ValveState::Closed;
+            return cornucopia::ugly_duckling::peripherals::api::ValveState::Closed;
         } else {
-            return farmhub::peripherals::api::ValveState::Open;
+            return cornucopia::ugly_duckling::peripherals::api::ValveState::Open;
         }
     }
 

--- a/components/peripherals-api/src/peripherals/api/TargetState.hpp
+++ b/components/peripherals-api/src/peripherals/api/TargetState.hpp
@@ -4,7 +4,7 @@
 
 #include <ArduinoJson.h>
 
-namespace farmhub::peripherals::api {
+namespace cornucopia::ugly_duckling::peripherals::api {
 
 enum class TargetState : int8_t {
     Closed = -1,
@@ -25,11 +25,11 @@ inline static const char* toString(std::optional<TargetState> state) {
     }
 }
 
-}    // namespace farmhub::peripherals::api
+}    // namespace cornucopia::ugly_duckling::peripherals::api
 
 namespace ArduinoJson {
 
-using farmhub::peripherals::api::TargetState;
+using cornucopia::ugly_duckling::peripherals::api::TargetState;
 
 template <>
 struct Converter<TargetState> {
@@ -44,12 +44,12 @@ struct Converter<TargetState> {
         }
     }
 
-    static farmhub::peripherals::api::TargetState fromJson(JsonVariantConst src) {
+    static cornucopia::ugly_duckling::peripherals::api::TargetState fromJson(JsonVariantConst src) {
         auto* str = src.as<const char*>();
         if (strcmp(str, "Closed") == 0) {
-            return farmhub::peripherals::api::TargetState::Closed;
+            return cornucopia::ugly_duckling::peripherals::api::TargetState::Closed;
         } else {
-            return farmhub::peripherals::api::TargetState::Open;
+            return cornucopia::ugly_duckling::peripherals::api::TargetState::Open;
         }
     }
 

--- a/components/peripherals-api/src/peripherals/api/TargetState.hpp
+++ b/components/peripherals-api/src/peripherals/api/TargetState.hpp
@@ -44,12 +44,12 @@ struct Converter<TargetState> {
         }
     }
 
-    static cornucopia::ugly_duckling::peripherals::api::TargetState fromJson(JsonVariantConst src) {
+    static TargetState fromJson(JsonVariantConst src) {
         auto* str = src.as<const char*>();
         if (strcmp(str, "Closed") == 0) {
-            return cornucopia::ugly_duckling::peripherals::api::TargetState::Closed;
+            return TargetState::Closed;
         } else {
-            return cornucopia::ugly_duckling::peripherals::api::TargetState::Open;
+            return TargetState::Open;
         }
     }
 

--- a/components/peripherals-api/src/peripherals/api/Units.hpp
+++ b/components/peripherals-api/src/peripherals/api/Units.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-namespace farmhub::peripherals::api {
+namespace cornucopia::ugly_duckling::peripherals::api {
 
 using Celsius = double;
 using Liters = double;
 using Lux = double;
 using Percent = double;    // 0..100
 
-}    // namespace farmhub::peripherals::api
+}    // namespace cornucopia::ugly_duckling::peripherals::api

--- a/components/peripherals/src/peripherals/I2CSettings.hpp
+++ b/components/peripherals/src/peripherals/I2CSettings.hpp
@@ -6,9 +6,9 @@
 #include <I2CManager.hpp>
 
 using namespace std::chrono;
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
-namespace farmhub::peripherals {
+namespace cornucopia::ugly_duckling::peripherals {
 
 class I2CSettings
     : public ConfigurationSection {
@@ -35,4 +35,4 @@ public:
     }
 };
 
-}    // namespace farmhub::peripherals
+}    // namespace cornucopia::ugly_duckling::peripherals

--- a/components/peripherals/src/peripherals/Motors.cpp
+++ b/components/peripherals/src/peripherals/Motors.cpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <string>
 
-namespace farmhub::peripherals {
+namespace cornucopia::ugly_duckling::peripherals {
 
 std::shared_ptr<PwmMotorDriver> findMotor(
     const std::map<std::string, std::shared_ptr<PwmMotorDriver>>& motors,
@@ -22,4 +22,4 @@ std::shared_ptr<PwmMotorDriver> findMotor(
     throw PeripheralCreationException("failed to find motor: " + motorName);
 }
 
-}    // namespace farmhub::peripherals
+}    // namespace cornucopia::ugly_duckling::peripherals

--- a/components/peripherals/src/peripherals/Motors.hpp
+++ b/components/peripherals/src/peripherals/Motors.hpp
@@ -6,12 +6,12 @@
 
 #include <drivers/MotorDriver.hpp>
 
-using namespace farmhub::kernel::drivers;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
 
-namespace farmhub::peripherals {
+namespace cornucopia::ugly_duckling::peripherals {
 
 std::shared_ptr<PwmMotorDriver> findMotor(
     const std::map<std::string, std::shared_ptr<PwmMotorDriver>>& motors,
     const std::string& motorName);
 
-}    // namespace farmhub::peripherals
+}    // namespace cornucopia::ugly_duckling::peripherals

--- a/components/peripherals/src/peripherals/Peripheral.hpp
+++ b/components/peripherals/src/peripherals/Peripheral.hpp
@@ -23,11 +23,11 @@
 
 #include "PeripheralException.hpp"
 
-using namespace farmhub::kernel;
-using namespace farmhub::kernel::drivers;
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 
-namespace farmhub::peripherals {
+namespace cornucopia::ugly_duckling::peripherals {
 
 class Peripheral
     : public virtual IPeripheral,
@@ -171,4 +171,4 @@ private:
     SettingsBasedManager<PeripheralFactory> manager;
 };
 
-}    // namespace farmhub::peripherals
+}    // namespace cornucopia::ugly_duckling::peripherals

--- a/components/peripherals/src/peripherals/PeripheralException.hpp
+++ b/components/peripherals/src/peripherals/PeripheralException.hpp
@@ -2,7 +2,7 @@
 
 #include <stdexcept>
 
-namespace farmhub::peripherals {
+namespace cornucopia::ugly_duckling::peripherals {
 
 class PeripheralCreationException
     : public std::runtime_error {
@@ -12,4 +12,4 @@ public:
     }
 };
 
-}    // namespace farmhub::peripherals
+}    // namespace cornucopia::ugly_duckling::peripherals

--- a/components/peripherals/src/peripherals/analog_meter/AnalogMeter.hpp
+++ b/components/peripherals/src/peripherals/analog_meter/AnalogMeter.hpp
@@ -15,10 +15,10 @@
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
-using namespace farmhub::kernel;
-using namespace farmhub::kernel::mqtt;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::kernel::mqtt;
 
-namespace farmhub::peripherals::analog_meter {
+namespace cornucopia::ugly_duckling::peripherals::analog_meter {
 
 LOGGING_TAG(ANALOG_METER, "analog-meter")
 
@@ -93,4 +93,4 @@ inline PeripheralFactory makeFactory() {
         });
 }
 
-}    // namespace farmhub::peripherals::analog_meter
+}    // namespace cornucopia::ugly_duckling::peripherals::analog_meter

--- a/components/peripherals/src/peripherals/door/Door.hpp
+++ b/components/peripherals/src/peripherals/door/Door.hpp
@@ -21,14 +21,14 @@
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/IDoor.hpp>
 
-using namespace farmhub::kernel;
-using namespace farmhub::kernel::drivers;
-using namespace farmhub::peripherals;
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
+using namespace cornucopia::ugly_duckling::peripherals;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-namespace farmhub::peripherals::door {
+namespace cornucopia::ugly_duckling::peripherals::door {
 
 LOGGING_TAG(DOOR, "door")
 
@@ -401,11 +401,11 @@ inline PeripheralFactory makeFactory(const std::map<std::string, std::shared_ptr
         });
 }
 
-}    // namespace farmhub::peripherals::door
+}    // namespace cornucopia::ugly_duckling::peripherals::door
 
 namespace ArduinoJson {
 
-using farmhub::peripherals::door::OperationState;
+using cornucopia::ugly_duckling::peripherals::door::OperationState;
 
 template <>
 struct Converter<OperationState> {

--- a/components/peripherals/src/peripherals/environment/ChirpSoilSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/ChirpSoilSensor.hpp
@@ -14,10 +14,10 @@
 
 #include "Environment.hpp"
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::peripherals::environment {
+namespace cornucopia::ugly_duckling::peripherals::environment {
 
 class ChirpSoilSensorSettings
     : public I2CSettings {
@@ -125,4 +125,4 @@ inline PeripheralFactory makeFactoryForChirpSoilSensor() {
         });
 }
 
-}    // namespace farmhub::peripherals::environment
+}    // namespace cornucopia::ugly_duckling::peripherals::environment

--- a/components/peripherals/src/peripherals/environment/Ds18B20SoilSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Ds18B20SoilSensor.hpp
@@ -14,11 +14,11 @@
 
 #include "Environment.hpp"
 
-using namespace farmhub::kernel;
-using namespace farmhub::kernel::mqtt;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::kernel::mqtt;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::peripherals::environment {
+namespace cornucopia::ugly_duckling::peripherals::environment {
 
 struct Ds18B20Settings : ConfigurationSection {
     Property<InternalPinPtr> pin { this, "pin" };
@@ -114,4 +114,4 @@ inline PeripheralFactory makeFactoryForDs18b20() {
         });
 }
 
-}    // namespace farmhub::peripherals::environment
+}    // namespace cornucopia::ugly_duckling::peripherals::environment

--- a/components/peripherals/src/peripherals/environment/Environment.hpp
+++ b/components/peripherals/src/peripherals/environment/Environment.hpp
@@ -10,11 +10,11 @@
 #include <peripherals/Peripheral.hpp>
 #include <utility>
 
-using namespace farmhub::kernel;
-using namespace farmhub::kernel::mqtt;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::kernel::mqtt;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::peripherals::environment {
+namespace cornucopia::ugly_duckling::peripherals::environment {
 
 LOGGING_TAG(ENV, "env")
 
@@ -26,4 +26,4 @@ public:
     virtual double getMoisture() = 0;
 };
 
-}    // namespace farmhub::peripherals::environment
+}    // namespace cornucopia::ugly_duckling::peripherals::environment

--- a/components/peripherals/src/peripherals/environment/Hw390SoilMoistureSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Hw390SoilMoistureSensor.hpp
@@ -8,10 +8,10 @@
 
 #include <utils/DebouncedMeasurement.hpp>
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::peripherals::environment {
+namespace cornucopia::ugly_duckling::peripherals::environment {
 
 class Hw390SoilMoistureSensorSettings
     : public ConfigurationSection {
@@ -99,4 +99,4 @@ inline PeripheralFactory makeFactoryForHw390SoilMoisture(const std::string& fact
         });
 }
 
-}    // namespace farmhub::peripherals::environment
+}    // namespace cornucopia::ugly_duckling::peripherals::environment

--- a/components/peripherals/src/peripherals/environment/KalmanFilterSoilSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/KalmanFilterSoilSensor.hpp
@@ -13,9 +13,9 @@
 #include "Environment.hpp"
 
 using namespace std::chrono;
-using namespace farmhub::utils::scheduling;
+using namespace cornucopia::ugly_duckling::utils::scheduling;
 
-namespace farmhub::peripherals::environment {
+namespace cornucopia::ugly_duckling::peripherals::environment {
 
 /**
  * @brief Reports real soil moisture levels calculated from raw moisture and temperature data using a Kalman filter.
@@ -152,4 +152,4 @@ inline PeripheralFactory makeFactoryForKalmanSoilMoisture() {
         });
 }
 
-}    // namespace farmhub::peripherals::environment
+}    // namespace cornucopia::ugly_duckling::peripherals::environment

--- a/components/peripherals/src/peripherals/environment/NtcTemperatureSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/NtcTemperatureSensor.hpp
@@ -11,10 +11,10 @@
 
 #include <utils/DebouncedMeasurement.hpp>
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 
-namespace farmhub::peripherals::environment {
+namespace cornucopia::ugly_duckling::peripherals::environment {
 
 class NtcTemperatureSensor final
     : virtual public ITemperatureSensor,
@@ -76,4 +76,4 @@ inline PeripheralFactory makeFactoryForNtcTemperatureSensor() {
         });
 }
 
-}    // namespace farmhub::peripherals::environment
+}    // namespace cornucopia::ugly_duckling::peripherals::environment

--- a/components/peripherals/src/peripherals/environment/Sht2xSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Sht2xSensor.hpp
@@ -12,10 +12,10 @@
 
 #include "Environment.hpp"
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::peripherals::environment {
+namespace cornucopia::ugly_duckling::peripherals::environment {
 
 /**
  * @brief Works with SHT2x or HTU2x.
@@ -90,4 +90,4 @@ inline PeripheralFactory makeFactoryForSht2x(const std::string& sensorKey) {
         });
 }
 
-}    // namespace farmhub::peripherals::environment
+}    // namespace cornucopia::ugly_duckling::peripherals::environment

--- a/components/peripherals/src/peripherals/environment/Sht3xSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Sht3xSensor.hpp
@@ -15,10 +15,10 @@
 #include "Environment.hpp"
 
 using namespace std::chrono;
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::peripherals::environment {
+namespace cornucopia::ugly_duckling::peripherals::environment {
 
 class Sht3xSensor final
     : public EnvironmentSensor,
@@ -108,4 +108,4 @@ inline PeripheralFactory makeFactoryForSht3x() {
         });
 }
 
-}    // namespace farmhub::peripherals::environment
+}    // namespace cornucopia::ugly_duckling::peripherals::environment

--- a/components/peripherals/src/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/components/peripherals/src/peripherals/fence/ElectricFenceMonitor.hpp
@@ -11,10 +11,10 @@
 #include <utility>
 
 using namespace std::chrono_literals;
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::peripherals::fence {
+namespace cornucopia::ugly_duckling::peripherals::fence {
 
 struct FencePinConfig {
     InternalPinPtr pin;
@@ -103,11 +103,11 @@ inline PeripheralFactory makeFactory() {
         });
 }
 
-}    // namespace farmhub::peripherals::fence
+}    // namespace cornucopia::ugly_duckling::peripherals::fence
 
 namespace ArduinoJson {
 
-using farmhub::peripherals::fence::FencePinConfig;
+using cornucopia::ugly_duckling::peripherals::fence::FencePinConfig;
 
 template <>
 struct Converter<FencePinConfig> {

--- a/components/peripherals/src/peripherals/flow_meter/FlowMeter.hpp
+++ b/components/peripherals/src/peripherals/flow_meter/FlowMeter.hpp
@@ -15,10 +15,10 @@
 #include <peripherals/api/IFlowMeter.hpp>
 
 using namespace std::chrono;
-using namespace farmhub::kernel::mqtt;
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::kernel::mqtt;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 
-namespace farmhub::peripherals::flow_meter {
+namespace cornucopia::ugly_duckling::peripherals::flow_meter {
 
 class FlowMeterSettings
     : public ConfigurationSection {
@@ -139,4 +139,4 @@ inline PeripheralFactory makeFactory() {
         });
 }
 
-}    // namespace farmhub::peripherals::flow_meter
+}    // namespace cornucopia::ugly_duckling::peripherals::flow_meter

--- a/components/peripherals/src/peripherals/light_sensor/AnalogLightSensor.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/AnalogLightSensor.hpp
@@ -17,10 +17,10 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::peripherals::light_sensor {
+namespace cornucopia::ugly_duckling::peripherals::light_sensor {
 
 class AnalogLightSensorSettings
     : public I2CSettings {
@@ -91,4 +91,4 @@ inline PeripheralFactory makeFactoryForAnalogLightSensor() {
         });
 }
 
-}    // namespace farmhub::peripherals::light_sensor
+}    // namespace cornucopia::ugly_duckling::peripherals::light_sensor

--- a/components/peripherals/src/peripherals/light_sensor/Bh1750.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/Bh1750.hpp
@@ -19,10 +19,10 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::peripherals::light_sensor {
+namespace cornucopia::ugly_duckling::peripherals::light_sensor {
 
 class Bh1750Settings
     : public I2CSettings {
@@ -84,4 +84,4 @@ inline PeripheralFactory makeFactoryForBh1750() {
         });
 }
 
-}    // namespace farmhub::peripherals::light_sensor
+}    // namespace cornucopia::ugly_duckling::peripherals::light_sensor

--- a/components/peripherals/src/peripherals/light_sensor/LightSensor.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/LightSensor.hpp
@@ -16,11 +16,11 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals;
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 
-namespace farmhub::peripherals::light_sensor {
+namespace cornucopia::ugly_duckling::peripherals::light_sensor {
 
 class LightSensor
     : public api::ILightSensor,
@@ -64,4 +64,4 @@ private:
     MovingAverage<double> level;
 };
 
-}    // namespace farmhub::peripherals::light_sensor
+}    // namespace cornucopia::ugly_duckling::peripherals::light_sensor

--- a/components/peripherals/src/peripherals/light_sensor/Tsl2591.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/Tsl2591.hpp
@@ -17,10 +17,10 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-using namespace farmhub::kernel;
-using namespace farmhub::peripherals;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
 
-namespace farmhub::peripherals::light_sensor {
+namespace cornucopia::ugly_duckling::peripherals::light_sensor {
 
 static constexpr uint8_t TSL2591_ADDR = 0x29;
 
@@ -93,4 +93,4 @@ inline PeripheralFactory makeFactoryForTsl2591() {
         });
 }
 
-}    // namespace farmhub::peripherals::light_sensor
+}    // namespace cornucopia::ugly_duckling::peripherals::light_sensor

--- a/components/peripherals/src/peripherals/multiplexer/Xl9535.hpp
+++ b/components/peripherals/src/peripherals/multiplexer/Xl9535.hpp
@@ -4,7 +4,7 @@
 #include <Pin.hpp>
 #include <utility>
 
-namespace farmhub::peripherals::multiplexer {
+namespace cornucopia::ugly_duckling::peripherals::multiplexer {
 
 class Xl9535Settings
     : public I2CSettings {
@@ -125,4 +125,4 @@ inline PeripheralFactory makeFactoryForXl9535() {
         });
 }
 
-}    // namespace farmhub::peripherals::multiplexer
+}    // namespace cornucopia::ugly_duckling::peripherals::multiplexer

--- a/components/peripherals/src/peripherals/valve/Valve.hpp
+++ b/components/peripherals/src/peripherals/valve/Valve.hpp
@@ -19,11 +19,11 @@
 #include <peripherals/valve/ValveControlStrategy.hpp>
 
 using namespace std::chrono;
-using namespace farmhub::kernel::drivers;
-using namespace farmhub::peripherals;
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
+using namespace cornucopia::ugly_duckling::peripherals;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 
-namespace farmhub::peripherals::valve {
+namespace cornucopia::ugly_duckling::peripherals::valve {
 
 class Valve final
     : public api::IValve,
@@ -152,4 +152,4 @@ private:
     std::optional<ValveState> state;
 };
 
-}    // namespace farmhub::peripherals::valve
+}    // namespace cornucopia::ugly_duckling::peripherals::valve

--- a/components/peripherals/src/peripherals/valve/ValveControlStrategy.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveControlStrategy.hpp
@@ -9,10 +9,10 @@
 #include <peripherals/api/IValve.hpp>
 
 using namespace std::chrono;
-using namespace farmhub::kernel::drivers;
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 
-namespace farmhub::peripherals::valve {
+namespace cornucopia::ugly_duckling::peripherals::valve {
 
 enum class ValveControlStrategyType : uint8_t {
     NormallyOpen,
@@ -188,4 +188,4 @@ private:
     PinPtr pin;
 };
 
-}    // namespace farmhub::peripherals::valve
+}    // namespace cornucopia::ugly_duckling::peripherals::valve

--- a/components/peripherals/src/peripherals/valve/ValveFactory.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveFactory.hpp
@@ -19,12 +19,12 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-using namespace farmhub::kernel;
-using namespace farmhub::kernel::drivers;
-using namespace farmhub::peripherals;
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::kernel::drivers;
+using namespace cornucopia::ugly_duckling::peripherals;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 
-namespace farmhub::peripherals::valve {
+namespace cornucopia::ugly_duckling::peripherals::valve {
 
 inline PeripheralFactory makeFactory(
     const std::map<std::string, std::shared_ptr<PwmMotorDriver>>& motors,
@@ -49,4 +49,4 @@ inline PeripheralFactory makeFactory(
         defaultStrategy);
 }
 
-}    // namespace farmhub::peripherals::valve
+}    // namespace cornucopia::ugly_duckling::peripherals::valve

--- a/components/peripherals/src/peripherals/valve/ValveSettings.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveSettings.hpp
@@ -12,9 +12,9 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
-namespace farmhub::peripherals::valve {
+namespace cornucopia::ugly_duckling::peripherals::valve {
 
 class ValveSettings
     : public ConfigurationSection {
@@ -81,11 +81,11 @@ public:
     }
 };
 
-}    // namespace farmhub::peripherals::valve
+}    // namespace cornucopia::ugly_duckling::peripherals::valve
 
 namespace ArduinoJson {
 
-using farmhub::peripherals::valve::ValveControlStrategyType;
+using cornucopia::ugly_duckling::peripherals::valve::ValveControlStrategyType;
 
 template <>
 struct Converter<ValveControlStrategyType> {

--- a/components/scheduling/src/scheduling/CompositeScheduler.hpp
+++ b/components/scheduling/src/scheduling/CompositeScheduler.hpp
@@ -7,7 +7,7 @@
 
 #include "IScheduler.hpp"
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 
 struct CompositeScheduler : IScheduler {
     template <std::derived_from<IScheduler>... Schedulers>
@@ -45,4 +45,4 @@ private:
     std::vector<std::shared_ptr<IScheduler>> schedulers;
 };
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling

--- a/components/scheduling/src/scheduling/DelayScheduler.hpp
+++ b/components/scheduling/src/scheduling/DelayScheduler.hpp
@@ -10,7 +10,7 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 
 struct DelaySchedule {
     seconds open;
@@ -145,4 +145,4 @@ private:
     std::optional<time_point<steady_clock>> transitionStartTime;
 };
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling

--- a/components/scheduling/src/scheduling/IScheduler.hpp
+++ b/components/scheduling/src/scheduling/IScheduler.hpp
@@ -8,7 +8,7 @@
 
 #include <peripherals/api/TargetState.hpp>
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 
 LOGGING_TAG(SCHEDULING, "scheduling")
 
@@ -35,7 +35,7 @@ struct IScheduler {
     virtual const char* getName() const = 0;
 };
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling
 
 namespace ArduinoJson {
 

--- a/components/scheduling/src/scheduling/LightSensorScheduler.hpp
+++ b/components/scheduling/src/scheduling/LightSensorScheduler.hpp
@@ -12,9 +12,9 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 
 struct LightSensorSchedule {
     Lux open;
@@ -73,4 +73,4 @@ private:
     std::optional<LightSensorSchedule> target;
 };
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling

--- a/components/scheduling/src/scheduling/MoistureBasedScheduler.hpp
+++ b/components/scheduling/src/scheduling/MoistureBasedScheduler.hpp
@@ -16,9 +16,9 @@
 #include <scheduling/IScheduler.hpp>
 
 using namespace std::chrono_literals;
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 
 // ---------- Strong-ish units ----------
 using ms = std::chrono::milliseconds;
@@ -426,4 +426,4 @@ private:
     }
 };
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling

--- a/components/scheduling/src/scheduling/MoistureKalmanFilter.hpp
+++ b/components/scheduling/src/scheduling/MoistureKalmanFilter.hpp
@@ -3,7 +3,7 @@
 #include <array>
 #include <cmath>
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 /**
  * @brief Kalman filter to estimate true soil moisture and temperature sensitivity.
  *
@@ -128,4 +128,4 @@ private:
     std::array<std::array<double, 2>, 2> P {};
 };
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling

--- a/components/scheduling/src/scheduling/OverrideScheduler.hpp
+++ b/components/scheduling/src/scheduling/OverrideScheduler.hpp
@@ -6,7 +6,7 @@
 
 #include <scheduling/IScheduler.hpp>
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 
 using namespace std::chrono;
 
@@ -64,4 +64,4 @@ private:
     std::optional<OverrideSchedule> schedule;
 };
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling

--- a/components/scheduling/src/scheduling/TimeBasedScheduler.hpp
+++ b/components/scheduling/src/scheduling/TimeBasedScheduler.hpp
@@ -8,7 +8,7 @@
 #include <scheduling/IScheduler.hpp>
 #include <utils/Chrono.hpp>
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 
 using namespace std::chrono;
 
@@ -108,11 +108,11 @@ private:
     std::vector<TimeBasedSchedule> schedules;
 };
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling
 
 namespace ArduinoJson {
 
-using farmhub::utils::scheduling::TimeBasedSchedule;
+using cornucopia::ugly_duckling::utils::scheduling::TimeBasedSchedule;
 
 template <>
 struct Converter<TimeBasedSchedule> {

--- a/components/scheduling/test/scheduling/DelaySchedulerTest.cpp
+++ b/components/scheduling/test/scheduling/DelaySchedulerTest.cpp
@@ -13,8 +13,8 @@
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
-using namespace farmhub::peripherals::api;
-using namespace farmhub::utils::scheduling;
+using namespace cornucopia::ugly_duckling::peripherals::api;
+using namespace cornucopia::ugly_duckling::utils::scheduling;
 
 namespace {
 

--- a/components/scheduling/test/scheduling/Fakes.hpp
+++ b/components/scheduling/test/scheduling/Fakes.hpp
@@ -9,9 +9,9 @@
 
 #include <scheduling/MoistureBasedScheduler.hpp>
 
-using namespace farmhub::peripherals::api;
+using namespace cornucopia::ugly_duckling::peripherals::api;
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 
 struct FakeClock {
     ms time { 0 };
@@ -127,4 +127,4 @@ struct SoilSimulator {
     Config config;
 };
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling

--- a/components/scheduling/test/scheduling/LightSensorSchedulerTest.cpp
+++ b/components/scheduling/test/scheduling/LightSensorSchedulerTest.cpp
@@ -13,8 +13,8 @@
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
-using namespace farmhub::peripherals::api;
-using namespace farmhub::utils::scheduling;
+using namespace cornucopia::ugly_duckling::peripherals::api;
+using namespace cornucopia::ugly_duckling::utils::scheduling;
 
 namespace {
 

--- a/components/scheduling/test/scheduling/MoistureBasedSchedulerTest.cpp
+++ b/components/scheduling/test/scheduling/MoistureBasedSchedulerTest.cpp
@@ -10,7 +10,7 @@
 
 #include <utils/Chrono.hpp>
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 
 static constexpr SoilSimulator::Config BASIC_SOIL = {
     .gainPercentPerLiter = 1.0,
@@ -197,11 +197,11 @@ TEST_CASE("starts watering after evaporation reduces moisture") {
     REQUIRE(result.moisture > 59.0);
 }
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling
 
 namespace Catch {
 
-using farmhub::utils::scheduling::SimulationResult;
+using cornucopia::ugly_duckling::utils::scheduling::SimulationResult;
 
 template <>
 struct StringMaker<SimulationResult> {

--- a/components/scheduling/test/scheduling/MoistureKalmanFilterTest.cpp
+++ b/components/scheduling/test/scheduling/MoistureKalmanFilterTest.cpp
@@ -10,7 +10,7 @@
 
 using Catch::Approx;
 
-namespace farmhub::utils::scheduling {
+namespace cornucopia::ugly_duckling::utils::scheduling {
 
 struct SimulationConfig {
     double moistReal0 = 80.0;     // initial real moisture
@@ -166,4 +166,4 @@ TEST_CASE("tempRef usage: consistent estimates around chosen reference", "[kalma
     // so we don't compare beta directly here.
 }
 
-}    // namespace farmhub::utils::scheduling
+}    // namespace cornucopia::ugly_duckling::utils::scheduling

--- a/components/scheduling/test/scheduling/TestHelpers.hpp
+++ b/components/scheduling/test/scheduling/TestHelpers.hpp
@@ -10,14 +10,14 @@
 
 #include <scheduling/IScheduler.hpp>
 
-using namespace farmhub::utils::scheduling;
+using namespace cornucopia::ugly_duckling::utils::scheduling;
 
 namespace Catch {
 
 template <>
 struct StringMaker<ScheduleResult> {
     static std::string convert(ScheduleResult const& r) {
-        using farmhub::peripherals::api::toString;
+        using cornucopia::ugly_duckling::peripherals::api::toString;
         std::ostringstream oss;
         oss << "ScheduleResult{";
         oss << "target=" << toString(r.targetState) << ", ";

--- a/components/scheduling/test/scheduling/TestHelpers.hpp
+++ b/components/scheduling/test/scheduling/TestHelpers.hpp
@@ -12,12 +12,13 @@
 
 using namespace cornucopia::ugly_duckling::utils::scheduling;
 
+using cornucopia::ugly_duckling::peripherals::api::toString;
+
 namespace Catch {
 
 template <>
 struct StringMaker<ScheduleResult> {
     static std::string convert(ScheduleResult const& r) {
-        using cornucopia::ugly_duckling::peripherals::api::toString;
         std::ostringstream oss;
         oss << "ScheduleResult{";
         oss << "target=" << toString(r.targetState) << ", ";

--- a/components/scheduling/test/scheduling/TimeBasedSchedulerTest.cpp
+++ b/components/scheduling/test/scheduling/TimeBasedSchedulerTest.cpp
@@ -13,7 +13,7 @@
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
-using namespace farmhub::utils::scheduling;
+using namespace cornucopia::ugly_duckling::utils::scheduling;
 
 namespace Catch {
 

--- a/components/utils/src/utils/Chrono.hpp
+++ b/components/utils/src/utils/Chrono.hpp
@@ -5,7 +5,7 @@
 #include <concepts>
 #include <optional>
 
-namespace farmhub::utils {
+namespace cornucopia::ugly_duckling::utils {
 
 template <class Rep1, class Period1, class Rep2, class Period2>
 double chrono_ratio(
@@ -60,4 +60,4 @@ std::optional<std::chrono::duration<Rep, Period>> maxDuration(
     return std::max(*a, b);
 }
 
-}    // namespace farmhub::utils
+}    // namespace cornucopia::ugly_duckling::utils

--- a/components/utils/src/utils/DebouncedMeasurement.hpp
+++ b/components/utils/src/utils/DebouncedMeasurement.hpp
@@ -8,9 +8,9 @@
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
-namespace farmhub::utils {
+namespace cornucopia::ugly_duckling::utils {
 
 template <typename T>
 struct DebouncedParams {
@@ -61,4 +61,4 @@ private:
     Mutex mutex;
 };
 
-}    // namespace farmhub::utils
+}    // namespace cornucopia::ugly_duckling::utils

--- a/docs/MAC-Based-Device-Selection.md
+++ b/docs/MAC-Based-Device-Selection.md
@@ -20,7 +20,7 @@ to the top level, eliminating the compile-time generation split for same-target 
 ## Technical Challenge: Pin Lifecycle
 
 Each device definition file currently declares its pins as `static const` globals inside a
-shared `namespace farmhub::devices::pins`. Including more than one of these files in the same
+shared `namespace cornucopia::ugly_duckling::devices::pins`. Including more than one of these files in the same
 compilation unit causes two problems:
 
 1. **Name collisions** — all five files use the same namespace and the same pin names

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,4 +1,4 @@
-#ifdef FARMHUB_DEBUG
+#ifdef UD_DEBUG
 #include <cstdio>
 #endif
 
@@ -21,8 +21,8 @@
 
 #include <devices/GenericDevice.hpp>
 
-using namespace farmhub::devices;
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::devices;
+using namespace cornucopia::ugly_duckling::kernel;
 
 namespace {
 void startDeviceBasedOnMac() {
@@ -73,7 +73,7 @@ void startDeviceBasedOnMac() {
 }    // namespace
 
 extern "C" void app_main() {
-#ifdef FARMHUB_DEBUG
+#ifdef UD_DEBUG
     // Reset ANSI colors
     printf("\033[0m");
 #endif

--- a/test/embedded-tests/components/kernel-test/src/WatchdogTest.cpp
+++ b/test/embedded-tests/components/kernel-test/src/WatchdogTest.cpp
@@ -6,7 +6,7 @@
 
 #include <Watchdog.hpp>
 
-using namespace farmhub::kernel;
+using namespace cornucopia::ugly_duckling::kernel;
 
 TEST_CASE("can start and stop watchdog") {
     std::optional<WatchdogState> watchdogState;

--- a/tools/kalman/main.cpp
+++ b/tools/kalman/main.cpp
@@ -14,7 +14,7 @@
 
 #include "utils/scheduling/MoistureKalmanFilter.hpp"
 
-using farmhub::utils::scheduling::MoistureKalmanFilter;
+using cornucopia::ugly_duckling::utils::scheduling::MoistureKalmanFilter;
 
 struct DataPoint {
     std::string time;


### PR DESCRIPTION
Fixes #535

We've dropped "farmhub" for a long while now; let's use "ugly-duckling" or "cornucopia"; whichever is more relevant.