### PR TITLE
Always generate NVS config partition, drop FSUPLOAD flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,6 @@ jobs:
             ccache --max-size=${{ env.CCACHE_MAXSIZE }} && \
             idf.py build \
               -DUD_DEBUG=${{ matrix.ud_debug }} \
-              -DFSUPLOAD=1 \
               -DUD_LOG_VERBOSE=${{ env.UD_LOG_VERBOSE }} \
               && \
             esp-idf-sbom create -o build/ugly-duckling.spdx build/project_description.json && \
@@ -215,7 +214,7 @@ jobs:
           extra_docker_args: -v  ${{ env.CCACHE_DIR }}:/root/.ccache
           command: |
             ccache --max-size=${{ env.CCACHE_MAXSIZE }} && \
-            idf.py -DUD_GEN=MK6 -DUD_DEBUG=1 -DFSUPLOAD=1 -DWOKWI=1 -DWOKWI_MQTT_HOST=${{ env.HOSTNAME }} build && \
+            idf.py -DUD_GEN=MK6 -DUD_DEBUG=1 -DWOKWI=1 -DWOKWI_MQTT_HOST=${{ env.HOSTNAME }} build && \
             ccache -s
 
       - name: Run a Wokwi CI server

--- a/README.md
+++ b/README.md
@@ -204,21 +204,24 @@ idf.py build -DUD_GEN=MKX       # Carrot (ESP32-C6)
 idf.py flash
 ```
 
-If you also want to upload the NVS config partition with the firmware, add `-DFSUPLOAD=1` to the command:
+This flashes the full firmware: the bootloader, the partition table, the app, and the NVS config partition (generated from `config/device-config.json` and `config/network-config.json`).
+
+> [!WARNING]
+> Flashing the NVS partition will erase all NVS data on the device, including WiFi credentials.
+> This is intended for initial device setup or reconfiguration.
+
+To flash only the app (leaving the existing NVS partition untouched), use:
 
 ```bash
-idf.py -DFSUPLOAD=1 flash
+idf.py app-flash
 ```
-
-> **Note:** Flashing the NVS partition will erase all NVS data on the device, including WiFi credentials.
-> This is intended for initial device setup or reconfiguration.
 
 #### Uploading just config
 
-To upload only the NVS config partition (generated from `config/device-config.json` and `config/network-config.json`):
+To upload only the NVS config partition:
 
 ```bash
-idf.py -DFSUPLOAD=1 build
+idf.py build
 esptool.py write_flash 0x18000 build/config.bin
 ```
 
@@ -243,7 +246,7 @@ Can use [Wokwi](https://wokwi.com/) to run the firmware in a simulated environme
 For this the firmware must be built with `-DWOKWI=1`.
 
 ```bash
-idf.py -DUD_GEN=MK6 -DUD_DEBUG=0 -DFSUPLOAD=1 -DWOKWI=1 build
+idf.py -DUD_GEN=MK6 -DUD_DEBUG=0 -DWOKWI=1 build
 ```
 
 The opening a diagram in the [`wokwi`](wokwi) directory will start the simulation.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -7,26 +7,25 @@ idf_component_register(
         devices
 )
 
-# Use `idf.py -DFSUPLOAD=1 flash` to upload the NVS config partition
-if(DEFINED FSUPLOAD AND FSUPLOAD)
-    set(CONFIG_NVS_BIN "${CMAKE_BINARY_DIR}/config.bin")
-    # NVS partition size (must match partitions.csv)
-    set(CONFIG_NVS_SIZE "0x40000")
+# Generate the NVS config partition. Use `idf.py flash` to upload it along
+# with the firmware, or `idf.py app-flash` to upload only the app.
+set(CONFIG_NVS_BIN "${CMAKE_BINARY_DIR}/config.bin")
+# NVS partition size (must match partitions.csv)
+set(CONFIG_NVS_SIZE "0x40000")
 
-    set(GEN_CONFIG_NVS_SCRIPT "${CMAKE_SOURCE_DIR}/scripts/gen_config_nvs.py")
-    file(GLOB CONFIG_FILES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/config/*.json")
-    add_custom_command(
-        OUTPUT ${CONFIG_NVS_BIN}
-        COMMAND ${PYTHON} ${GEN_CONFIG_NVS_SCRIPT}
-            ${CMAKE_SOURCE_DIR}/config
-            ${CONFIG_NVS_BIN}
-            ${CONFIG_NVS_SIZE}
-        DEPENDS
-            ${CONFIG_FILES}
-            ${GEN_CONFIG_NVS_SCRIPT}
-        COMMENT "Generating NVS config partition"
-    )
-    add_custom_target(config_nvs_image ALL DEPENDS ${CONFIG_NVS_BIN})
+set(GEN_CONFIG_NVS_SCRIPT "${CMAKE_SOURCE_DIR}/scripts/gen_config_nvs.py")
+file(GLOB CONFIG_FILES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/config/*.json")
+add_custom_command(
+    OUTPUT ${CONFIG_NVS_BIN}
+    COMMAND ${PYTHON} ${GEN_CONFIG_NVS_SCRIPT}
+        ${CMAKE_SOURCE_DIR}/config
+        ${CONFIG_NVS_BIN}
+        ${CONFIG_NVS_SIZE}
+    DEPENDS
+        ${CONFIG_FILES}
+        ${GEN_CONFIG_NVS_SCRIPT}
+    COMMENT "Generating NVS config partition"
+)
+add_custom_target(config_nvs_image ALL DEPENDS ${CONFIG_NVS_BIN})
 
-    esptool_py_flash_to_partition(flash "nvs" ${CONFIG_NVS_BIN})
-endif()
+esptool_py_flash_to_partition(flash "nvs" ${CONFIG_NVS_BIN})

--- a/test/e2e-tests/main/CMakeLists.txt
+++ b/test/e2e-tests/main/CMakeLists.txt
@@ -1,3 +1,1 @@
-set(FSUPLOAD TRUE)
-
 include(../../../main/CMakeLists.txt)


### PR DESCRIPTION
`idf.py app-flash` already skips everything but the app, so there's no need for a separate build-time switch to opt into flashing the NVS config partition. Generate it unconditionally and document `flash` vs `app-flash` in the README.