### PR TITLE
Use MAC address in MQTT client ID

### DIFF
--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -187,10 +187,10 @@ std::shared_ptr<Watchdog> initWatchdog(seconds timeout) {
     });
 }
 
-std::shared_ptr<MqttRoot> initMqtt(const std::shared_ptr<ModuleStates>& states, const std::shared_ptr<NetworkConfig>& networkConfig, StateSource& mqttReady) {
+std::shared_ptr<MqttRoot> initMqtt(const std::shared_ptr<ModuleStates>& states, const std::string& clientId, const std::shared_ptr<NetworkConfig>& networkConfig, StateSource& mqttReady) {
     // NetworkConfig inherits from MqttDriver::Config, so we can upcast
     auto mqttConfig = std::static_pointer_cast<MqttDriver::Config>(networkConfig);
-    auto mqtt = std::make_shared<MqttDriver>(states->networkReady, mqttConfig, networkConfig->instance.get(), mqttReady);
+    auto mqtt = std::make_shared<MqttDriver>(states->networkReady, mqttConfig, clientId, mqttReady);
     const std::string& location = networkConfig->location.get();
     return std::make_shared<MqttRoot>(mqtt, (location.empty() ? "" : location + "/") + "devices/ugly-duckling/" + networkConfig->instance.get());
 }
@@ -382,6 +382,8 @@ static void startDevice() {
     );
     ConsoleProvider::init(logRecords, settings->publishLogs.get());
 
+    auto macAddress = getMacAddress();
+
     LOGD("\n"
          "   _   _       _         ____             _    _ _\n"
          "  | | | | __ _| |_   _  |  _ \\ _   _  ___| | _| (_)_ __   __ _\n"
@@ -395,7 +397,7 @@ static void startDevice() {
         modelWithRevision.c_str(),
         networkConfig->instance.get().c_str(),
         networkConfig->getHostname().c_str(),
-        getMacAddress().c_str());
+        macAddress.c_str());
 
     auto statusLed = std::make_shared<LedDriver>("status", deviceDefinition->statusPin);
     auto states = std::make_shared<ModuleStates>();
@@ -448,7 +450,8 @@ static void startDevice() {
     auto rtc = std::make_shared<RtcDriver>(wifi->getNetworkReady(), networkConfig->ntp.get(), states->rtcInSync);
 
     // Init MQTT connection
-    auto mqttRoot = initMqtt(states, networkConfig, states->mqttReady);
+    auto clientId = "ugly-duckling-" + macAddress;
+    auto mqttRoot = initMqtt(states, clientId, networkConfig, states->mqttReady);
     MqttLog::init(settings->publishLogs.get(), logRecords, mqttRoot);
     registerBasicCommands(mqttRoot);
     registerNvsCommands(mqttRoot);
@@ -545,12 +548,12 @@ static void startDevice() {
 
     mqttRoot->publish(
         "init",
-        [resetReason, settings, networkConfig, initState, peripheralsInitJson, functionsInitJson, powerManager, deviceDefinition](JsonObject& json) {
+        [resetReason, settings, macAddress, networkConfig, initState, peripheralsInitJson, functionsInitJson, powerManager, deviceDefinition](JsonObject& json) {
             json["model"] = deviceDefinition->model;
             json["revision"] = deviceDefinition->revision;
             json["platform"] = UD_PLATFORM;
             json["instance"] = networkConfig->instance.get();
-            json["mac"] = getMacAddress();
+            json["mac"] = macAddress;
             auto device = json["settings"].to<JsonObject>();
             settings->store(device);
             json["version"] = firmwareVersion;

--- a/components/kernel/src/mqtt/MqttDriver.hpp
+++ b/components/kernel/src/mqtt/MqttDriver.hpp
@@ -55,7 +55,6 @@ public:
     public:
         Property<std::string> host { this, "host", "" };
         Property<unsigned int> port { this, "port", 1883 };
-        Property<std::string> clientId { this, "clientId", "" };
         Property<size_t> queueSize { this, "queueSize", 128 };
         ArrayProperty<std::string> serverCert { this, "serverCert" };
         ArrayProperty<std::string> clientCert { this, "clientCert" };
@@ -65,7 +64,7 @@ public:
     MqttDriver(
         State& networkReady,
         const std::shared_ptr<Config>& config,
-        const std::string& instanceName,
+        const std::string& clientId,
         StateSource& ready)
         : networkReady(networkReady)
         , configHostname(config->host.get())
@@ -73,7 +72,7 @@ public:
         , configServerCert(joinStrings(config->serverCert.get()))
         , configClientCert(joinStrings(config->clientCert.get()))
         , configClientKey(joinStrings(config->clientKey.get()))
-        , clientId(getClientId(config->clientId.get(), instanceName))
+        , clientId(clientId)
         , ready(ready)
         , eventQueue("mqtt-outgoing", config->queueSize.get())
         , incomingQueue("mqtt-incoming", config->queueSize.get()) {
@@ -636,13 +635,6 @@ private:
         }
         LOGTW(MQTT, "No handler for topic '%s'",
             topic.c_str());
-    }
-
-    static std::string getClientId(const std::string& clientId, const std::string& instanceName) {
-        if (!clientId.empty()) {
-            return clientId;
-        }
-        return "ugly-duckling-" + instanceName;
     }
 
     static bool topicMatches(const char* pattern, const char* topic) {


### PR DESCRIPTION
This way devices cannot collide with each other. Previously we used the instance name and that caused devices with the same instance name under different locations to "kick each other out" when both went online.