### PR TITLE
Add support for Spadefoot Toad MK1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,34 +1,60 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
+## Project Structure
 
-- Firmware entrypoint in `main/` (see `main/main.cpp`); board-specific definitions in `components/devices/src/devices/*.hpp`; shared logic in `components/kernel`, `components/peripherals`, `components/peripherals-api`, `components/utils`, and `components/functions`.
-- Test-support utilities live in `components/test-support`; test suites sit under `test/unit-tests`, `test/embedded-tests`, and `test/e2e-tests`.
-- NVS config files live in `config/` (with templates in `config-templates/`); Wokwi diagrams in `wokwi/`; docs and examples in `docs/`; generated outputs in `build/`.
-- Helper scripts stay at repo root (e.g., `generate-clang-tidy-compile-db.py`, `lookup-backtrace.py`, `idf-docker.py`) and in `scripts/`; CI workflows mirror the local steps.
+```
+main/               # App entry point (main.cpp); MAC-based device selection
+components/
+  kernel/           # WiFi, MQTT, NTP, RTC, telemetry, NVS, power management
+  devices/          # Hardware model definitions (pin assignments, on-board drivers)
+  peripherals/      # Sensor and actuator implementations
+  peripherals-api/  # Peripheral interfaces (IPeripheral, IValve, …)
+  scheduling/       # Scheduling strategies (time, moisture, light, composite)
+  functions/        # High-level device logic (PlotController, ChickenDoor)
+  utils/            # Shared utilities (Chrono, DebouncedMeasurement)
+  test-support/     # Test-only helpers (FakeLog)
+test/
+  unit-tests/       # Native Catch2 tests (no hardware)
+  embedded-tests/   # ESP-IDF Catch2 tests (runs on Wokwi)
+  e2e-tests/        # Full MQTT + Wokwi end-to-end tests
+config/             # Runtime NVS config files (device-config.json, network-config.json)
+config-templates/   # Config templates by device type (never commit real credentials)
+wokwi/              # Wokwi diagrams and local dev-env (docker-compose + Mosquitto)
+docs/               # Architecture, component, coding standards, and spec documents
+scripts/            # Build helpers (gen_config_nvs.py)
+tools/              # Development tools
+```
 
-See [README.md](README.md) for configuration storage layout, build, flash, and development commands.
+See [docs/Architecture.md](docs/Architecture.md) for system-level architecture and the platform/model matrix.
+See [docs/Components.md](docs/Components.md) for the peripheral/function/feature model.
+See [README.md](README.md) for build, flash, and development commands.
 
-## Coding Style & Naming Conventions
+## Coding Style
 
-- Follow `.editorconfig`: LF endings, 4-space indent (2 for JSON/YAML/Markdown). C++ is formatted with WebKit-flavored `.clang-format` (attached braces, left-aligned pointers, no single-line functions).
-- Static analysis via `.clang-tidy` (warnings-as-errors). Regenerate the compile DB with `python ./generate-clang-tidy-compile-db.py` and run `clang-tidy -p build/clang-tidy ...`.
-- Naming: types in PascalCase (`UglyDucklingMk6`), functions/methods camelCase, constants/macros UPPER_SNAKE (`UD_GEN`, `UD_DEBUG`); keep namespaces compact per config.
-- Markdown: keep headings sequential, lists properly indented, and wrap code blocks in fences; follow markdownlint defaults (no trailing spaces, blank line before lists and headings).
+See [docs/CodingStandards.md](docs/CodingStandards.md) for formatting rules, clang-tidy usage, naming conventions, and Markdown style.
+
+Quick reference:
+
+- LF endings, 4-space indent (2 for JSON/YAML/Markdown). WebKit `.clang-format`, warnings-as-errors via `.clang-tidy`.
+- Types: `PascalCase` — functions/methods: `camelCase` — macros/constants: `UPPER_SNAKE`.
 
 ## Testing Guidelines
 
-- Add/extend tests alongside the closest suite: fast logic in `test/unit-tests/main`, IDF-integrated flows in `test/embedded-tests`, MQTT/WiFi behavior in `test/e2e-tests`. Prefer deterministic Wokwi fixtures over hardware.
-- Use clear test names mirroring the behavior under test; keep payload samples under `config-templates/` or dedicated fixtures instead of inline strings.
-- Capture artifacts (`pytest` logs, serial output) when touching connectivity, and document required env vars (`WOKWI_CLI_TOKEN`, `WOKWI_CLI_SERVER` as in CI).
+- Fast logic goes in `test/unit-tests/` (native Catch2, no hardware required).
+- IDF-integrated flows go in `test/embedded-tests/` (runs on Wokwi).
+- MQTT/WiFi behavior goes in `test/e2e-tests/` (full Wokwi + Mosquitto).
+- Prefer deterministic Wokwi fixtures over physical hardware.
+- Use test names that mirror the behavior under test.
+- Keep payload samples in `config-templates/` or dedicated fixtures, not inline strings.
+- Document required env vars: `WOKWI_CLI_TOKEN`, `WOKWI_CLI_SERVER`.
 
 ## Commit & Pull Request Guidelines
 
-- Commit messages follow short, imperative summaries (examples: "Add debug property to init message", "Move all test templates to area-51"); keep scope focused.
-- PRs should state the target generation (`UD_GEN`/`IDF_TARGET`), what was tested (commands run, tokens used), and any artifacts (logs, Wokwi outputs). Link issues and note firmware or NVS config changes to ease OTA packaging.
+- Commit messages: short imperative summaries (e.g. "Add debug property to init message").
+- PRs must state: target platform (`spinach`/`carrot`, `IDF_TARGET`), what was tested (commands run, Wokwi tokens used), and any artifacts (logs, serial output). Link related issues and note NVS config changes.
 
 ## Security & Configuration Tips
 
-- Never commit real MQTT credentials, certificates, or device configs; keep samples under `config-templates/` and load real values into NVS locally or via MQTT NVS commands.
-- Prefer editing defaults (`sdkconfig.defaults`, `sdkconfig.*.defaults`) and regenerating `sdkconfig` rather than hand-editing the tracked file; avoid drifting from the CI matrix.
-- Keep `dependencies.lock` and `managed_components/` in sync with ESP-IDF tooling; avoid manual edits unless vendoring is intentional.
+- Never commit real MQTT credentials, TLS certificates, or device configs. Keep samples in `config-templates/`.
+- Prefer editing `sdkconfig.defaults` / `sdkconfig.*.defaults` and regenerating `sdkconfig` rather than hand-editing the tracked file.
+- Keep `dependencies.lock` and `managed_components/` in sync with ESP-IDF tooling; avoid manual edits unless intentionally vendoring.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Devices are identified by a location (denoting the installation site) and a uniq
 Devices can have multiple peripherals, such as sensors, actuators, and displays.
 Each peripheral is identified by its type and a name that is unique within the device.
 
+See [docs/Architecture.md](docs/Architecture.md) for the system architecture and [docs/Components.md](docs/Components.md) for the peripheral/function model.
+
 ## Hardware platforms and models
 
 Ugly Duckling hardware is organised into two layers:
@@ -26,8 +28,8 @@ There are currently two platforms:
 
 | Platform    | Chip     | Models                                     |
 | ----------- | -------- | ------------------------------------------ |
-| **Spinach** | ESP32-S3 | MK5, MK6 (rev1–rev3), MK7, MK8 (rev1–rev2) |
-| **Carrot**  | ESP32-C6 | MKX                                        |
+| **Spinach** | ESP32-S3 | MK5, MK6 (rev1–rev3), MK7, MK8 (rev1–rev2), MK9 rev1 |
+| **Carrot**  | ESP32-C6 | MK9 rev2                                              |
 
 Each platform produces a single firmware binary that covers all models on that platform.
 The correct model is selected at runtime based on the device's MAC address.
@@ -122,7 +124,7 @@ Once the device receives such configuration, it stores it under the `$FUNCTION_N
 ## Remote commands
 
 Ugly duckling devices and their peripherals both support receiving commands via MQTT.
-Commands are triggered via retained MQTT messages sent to `$DEVICE_ROOT/commands/$COMMAND` for devices, and `$DEVICE_`.
+Commands are triggered via retained MQTT messages sent to `$DEVICE_ROOT/commands/$COMMAND` for devices, and `$PERIPHERAL_ROOT/commands/$COMMAND` for peripherals.
 They typically respond under `$DEVICE_ROOT/responses/$COMMAND`.
 
 Once the device receives a command it deletes the retained message.
@@ -167,9 +169,7 @@ The following commands are available to manage NVS entries on the device:
 
 ### Prerequisites
 
-- ESP-IDF v6.0 (see [installation instructions](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/index.html))
-
-Actually needs [ESP-IDF-Clang Docker image](https://github.com/lptr/esp-idf-clang-docker).
+- [ESP-IDF-Clang Docker image](https://github.com/lptr/esp-idf-clang-docker) (wraps ESP-IDF v6.0 with Clang toolchain)
 
 ### Building
 
@@ -195,7 +195,8 @@ Make sure `IDF_TARGET` matches the platform the model belongs to:
 
 ```bash
 idf.py build -DUD_GEN=MK7       # Spinach (ESP32-S3)
-idf.py build -DUD_GEN=MKX       # Carrot (ESP32-C6)
+idf.py build -DUD_GEN=MK9       # Carrot (ESP32-C6, MK9 rev2)
+idf.py build -DUD_GEN=MK9_REV1  # Spinach (ESP32-S3, MK9 rev1)
 ```
 
 ### Flashing
@@ -258,21 +259,38 @@ After that from the "Run and Debug" panel select the "Wokwi GDB" configuration a
 
 ### Testing
 
-To run unit tests using Wokwi:
+There are three test suites:
+
+#### Unit tests (native, no hardware required)
 
 ```bash
 cd test/unit-tests
-idf.py build
-pytest --embedded-services idf,wokwi pytest_unit-tests.py
+cmake -B build -G Ninja
+ninja -C build
+./build/unit-tests
 ```
 
-Make sure to set the `WOKWI_CLI_TOKEN` environment variable.
+#### Embedded tests (Wokwi simulator)
 
-If `pytest` is not available, install it by running in the currently used ESP-IDF version home:
+```bash
+cd test/embedded-tests
+idf.py build
+pytest --embedded-services idf,wokwi pytest_embedded-tests.py
+```
+
+#### End-to-end tests (Wokwi + MQTT)
+
+```bash
+cd test/e2e-tests
+idf.py build
+pytest pytest_e2e-tests.py
+```
+
+Set `WOKWI_CLI_TOKEN` (and optionally `WOKWI_CLI_SERVER`) before running Wokwi-based tests.
+
+If `pytest` is not available, install it using the ESP-IDF Python environment:
 
 ```bash
 ./install.sh --enable-pytest
 pip install pytest-embedded-wokwi
 ```
-
-(Make sure to run with the right IDF-installed Python version so `pytest` is installed in the right environment.)

--- a/components/devices/src/devices/DeviceDefinition.hpp
+++ b/components/devices/src/devices/DeviceDefinition.hpp
@@ -29,6 +29,7 @@
 #include <peripherals/environment/Sht3xSensor.hpp>
 #include <peripherals/environment/ChirpSoilSensor.hpp>
 #include <peripherals/environment/Hw390SoilMoistureSensor.hpp>
+#include <peripherals/environment/SpadefootToadSensor.hpp>
 #include <peripherals/fence/ElectricFenceMonitor.hpp>
 #include <peripherals/flow_meter/FlowMeter.hpp>
 #include <peripherals/light_sensor/AnalogLightSensor.hpp>
@@ -82,6 +83,7 @@ public:
         // For backward compatibility with existing configs; can be removed after a while
         peripheralManager->registerFactory(environment::makeFactoryForHw390SoilMoisture("environment:soil-moisture"));
         peripheralManager->registerFactory(environment::makeFactoryForChirpSoilSensor());
+        peripheralManager->registerFactory(environment::makeFactoryForSpadefootToadSensor());
         peripheralManager->registerFactory(environment::makeFactoryForDs18b20());
         peripheralManager->registerFactory(environment::makeFactoryForKalmanSoilMoisture());
 

--- a/components/kernel/src/I2CManager.hpp
+++ b/components/kernel/src/I2CManager.hpp
@@ -27,7 +27,7 @@ public:
     uint8_t address;
     InternalPinPtr sda;
     InternalPinPtr scl;
-    uint32_t clkSpeed = 400000;
+    uint32_t clkSpeed = 400000;    // Hz; set by I2CSettings (which takes kHz) or overridden per-driver
 
     std::string toString() const {
         return "I2C address: " + toHexString(address) + ", SDA: " + sda->getName() + ", SCL: " + scl->getName() + ", clk: " + std::to_string(clkSpeed / 1000.0) + " kHz";

--- a/components/kernel/src/I2CManager.hpp
+++ b/components/kernel/src/I2CManager.hpp
@@ -2,6 +2,7 @@
 
 #include <exception>
 #include <memory>
+#include <vector>
 
 #include <driver/i2c_master.h>
 
@@ -26,9 +27,10 @@ public:
     uint8_t address;
     InternalPinPtr sda;
     InternalPinPtr scl;
+    uint32_t clkSpeed = 400000;
 
     std::string toString() const {
-        return "I2C address: " + toHexString(address) + ", SDA: " + sda->getName() + ", SCL: " + scl->getName();
+        return "I2C address: " + toHexString(address) + ", SDA: " + sda->getName() + ", SCL: " + scl->getName() + ", clk: " + std::to_string(clkSpeed / 1000.0) + " kHz";
     }
 };
 
@@ -47,7 +49,7 @@ struct I2CBus {
 
 class I2CDevice {
 public:
-    I2CDevice(const std::string& name, const std::shared_ptr<I2CBus>& bus, uint8_t address)
+    I2CDevice(const std::string& name, const std::shared_ptr<I2CBus>& bus, uint8_t address, uint32_t clkSpeed = 400000)
         : name(name)
         , bus(bus)
         , device({
@@ -68,9 +70,7 @@ public:
                   .scl_pullup_en = 1,
                   .clk_flags = 0,    // Use default clock flags
                   .master {
-                      // TODO Allow clock speed to be configured
-                      //      And use higher speed for internal I2C
-                      .clk_speed = 200000,
+                      .clk_speed = clkSpeed,
                   },
               },
           }) {
@@ -114,6 +114,16 @@ public:
         ESP_ERROR_THROW(i2c_dev_write(&device, &reg, 1, buffer, length));
     }
 
+    void writeByte(uint8_t cmd) {
+        ESP_ERROR_THROW(i2c_dev_write(&device, &cmd, 1, nullptr, 0));
+    }
+
+    std::vector<uint8_t> readBytes(uint8_t cmd, size_t n) {
+        std::vector<uint8_t> buffer(n);
+        ESP_ERROR_THROW(i2c_dev_read(&device, &cmd, 1, buffer.data(), n));
+        return buffer;
+    }
+
     std::shared_ptr<I2CBus> getBus() const {
         return bus;
     }
@@ -140,7 +150,10 @@ public:
     }
 
     std::shared_ptr<I2CDevice> createDevice(const std::string& name, const I2CConfig& config) {
-        return createDevice(name, config.sda, config.scl, config.address);
+        auto device = std::make_shared<I2CDevice>(name, getBusFor(config.sda, config.scl), config.address, config.clkSpeed);
+        LOGTI(I2C, "Created I2C device %s at address 0x%02x (clk: %.02f kHz)",
+            name.c_str(), config.address, config.clkSpeed / 1000.0);
+        return device;
     }
 
     std::shared_ptr<I2CDevice> createDevice(const std::string& name, const InternalPinPtr& sda, const InternalPinPtr& scl, uint8_t address) {

--- a/components/peripherals/src/peripherals/I2CSettings.hpp
+++ b/components/peripherals/src/peripherals/I2CSettings.hpp
@@ -19,6 +19,8 @@ public:
     Property<std::string> address { this, "address" };
     Property<InternalPinPtr> sda { this, "sda" };
     Property<InternalPinPtr> scl { this, "scl" };
+    // Clock speed in kHz (e.g. 100 for Standard Mode, 400 for Fast Mode)
+    Property<uint32_t> clkSpeed { this, "clkSpeed", 400 };
 
     I2CConfig parse(uint8_t defaultAddress = 0xFF, const InternalPinPtr& defaultSda = nullptr, const InternalPinPtr& defaultScl = nullptr) const {
         return {
@@ -30,7 +32,8 @@ public:
                 : sda.get(),
             .scl = scl.get() == nullptr
                 ? defaultScl
-                : scl.get()
+                : scl.get(),
+            .clkSpeed = clkSpeed.get() * 1000
         };
     }
 };

--- a/components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <stdexcept>
+
+#include <I2CManager.hpp>
+#include <Task.hpp>
+
+#include <peripherals/I2CSettings.hpp>
+#include <peripherals/Peripheral.hpp>
+#include <peripherals/api/ISoilMoistureSensor.hpp>
+#include <peripherals/api/ITemperatureSensor.hpp>
+
+#include <utils/DebouncedMeasurement.hpp>
+
+#include "Environment.hpp"
+
+using namespace cornucopia::ugly_duckling::kernel;
+using namespace cornucopia::ugly_duckling::peripherals;
+
+namespace cornucopia::ugly_duckling::peripherals::environment {
+
+class SpadefootToadSensorSettings
+    : public I2CSettings {
+    // No extra fields; I2C address comes from I2CSettings.
+};
+
+struct SpadefootToadReading {
+    double moisture = std::numeric_limits<double>::quiet_NaN();
+    double temperature = std::numeric_limits<double>::quiet_NaN();
+};
+
+class SpadefootToadSensor final
+    : public api::ISoilMoistureSensor,
+      public api::ITemperatureSensor,
+      public Peripheral {
+public:
+    SpadefootToadSensor(
+        const std::string& name,
+        const std::shared_ptr<I2CManager>& i2c,
+        const I2CConfig& config)
+        : Peripheral(name)
+        , device(i2c->createDevice(name, config)) {
+
+        LOGTI(ENV, "Initializing Spadefoot Toad soil sensor '%s' with %s",
+            name.c_str(), config.toString().c_str());
+
+        // Verify manufacturer ID
+        uint16_t mfrId = __builtin_bswap16(device->readRegWord(CMD_GET_MFR_ID));
+        if (mfrId != EXPECTED_MFR_ID) {
+            LOGTE(ENV, "Spadefoot Toad '%s': unexpected manufacturer ID 0x%04X (expected 0x%04X)",
+                name.c_str(), mfrId, EXPECTED_MFR_ID);
+            throw std::runtime_error("Spadefoot Toad: manufacturer ID mismatch");
+        }
+
+        // Verify device ID
+        uint16_t deviceId = __builtin_bswap16(device->readRegWord(CMD_GET_DEVICE_ID));
+        if (deviceId != EXPECTED_DEVICE_ID) {
+            LOGTE(ENV, "Spadefoot Toad '%s': unexpected device ID 0x%04X (expected 0x%04X)",
+                name.c_str(), deviceId, EXPECTED_DEVICE_ID);
+            throw std::runtime_error("Spadefoot Toad: device ID mismatch");
+        }
+
+        // Log firmware and device revisions
+        uint16_t firmwareRev = __builtin_bswap16(device->readRegWord(CMD_GET_FIRMWARE_REV));
+        LOGTI(ENV, "Spadefoot Toad firmware rev: 0x%04X", firmwareRev);
+
+        uint16_t deviceRev = __builtin_bswap16(device->readRegWord(CMD_GET_DEVICE_REV));
+        LOGTI(ENV, "Spadefoot Toad device rev: 0x%04X", deviceRev);
+    }
+
+    Percent getMoisture() override {
+        return measurement.getValue().moisture;
+    }
+
+    Celsius getTemperature() override {
+        return measurement.getValue().temperature;
+    }
+
+private:
+    static constexpr uint8_t CMD_TRIGGER = 0x01;
+    static constexpr uint8_t CMD_READ = 0x02;
+    static constexpr uint8_t CMD_GET_FIRMWARE_REV = 0xFC;
+    static constexpr uint8_t CMD_GET_DEVICE_REV = 0xFD;
+    static constexpr uint8_t CMD_GET_MFR_ID = 0xFE;
+    static constexpr uint8_t CMD_GET_DEVICE_ID = 0xFF;
+
+    static constexpr uint16_t EXPECTED_MFR_ID = 0x434D;
+    static constexpr uint16_t EXPECTED_DEVICE_ID = 0x0010;
+
+    static constexpr uint8_t FLAG_MOISTURE_VALID = 0x01;
+    static constexpr uint8_t FLAG_TEMPERATURE_VALID = 0x02;
+    static constexpr uint8_t MOISTURE_INVALID = 0xFF;
+    static constexpr int16_t TEMP_INVALID = INT16_MIN;
+
+    const std::shared_ptr<I2CDevice> device;
+
+    utils::DebouncedMeasurement<SpadefootToadReading> measurement {
+        [this](const utils::DebouncedParams<SpadefootToadReading>) -> std::optional<SpadefootToadReading> {
+            // Phase 1: trigger measurement
+            device->writeByte(CMD_TRIGGER);
+
+            // Phase 2: wait 1 s, then read results
+            Task::delay(1s);
+            auto raw = device->readBytes(CMD_READ, 10);
+
+            // Validate checksum (XOR of bytes [0..8])
+            uint8_t csum = 0;
+            for (int i = 0; i < 9; i++) {
+                csum ^= raw[i];
+            }
+            if (csum != raw[9]) {
+                LOGTW(ENV, "Spadefoot Toad '%s': checksum mismatch", getName().c_str());
+                return std::nullopt;
+            }
+
+            SpadefootToadReading reading;
+            uint8_t flags = raw[8];
+
+            // Moisture: average of valid probes (flag bit 0 set and value != 0xFF)
+            if (flags & FLAG_MOISTURE_VALID) {
+                int sum = 0, count = 0;
+                for (int i = 0; i < 4; i++) {
+                    if (raw[i] != MOISTURE_INVALID) {
+                        sum += raw[i];
+                        count++;
+                    }
+                }
+                if (count > 0) {
+                    reading.moisture = static_cast<double>(sum) / count;
+                }
+                LOGTV(ENV, "Spadefoot Toad '%s': moisture TF=%d TR=%d BF=%d BR=%d → avg=%.1f%%",
+                    getName().c_str(), raw[0], raw[1], raw[2], raw[3], reading.moisture);
+            }
+
+            // Temperature: average of top and bottom.
+            // Requires the temperature valid flag AND both individual readings to be valid.
+            if (flags & FLAG_TEMPERATURE_VALID) {
+                auto temp_top = static_cast<int16_t>((raw[4] << 8) | raw[5]);
+                auto temp_bot = static_cast<int16_t>((raw[6] << 8) | raw[7]);
+                if (temp_top != TEMP_INVALID && temp_bot != TEMP_INVALID) {
+                    reading.temperature = (temp_top + temp_bot) / 20.0;    // two sensors, 0.1 °C units
+                    LOGTV(ENV, "Spadefoot Toad '%s': temp top=%.1f°C bot=%.1f°C → avg=%.1f°C",
+                        getName().c_str(), temp_top / 10.0, temp_bot / 10.0, reading.temperature);
+                } else {
+                    LOGTW(ENV, "Spadefoot Toad '%s': temperature valid flag set but individual reading(s) invalid (top=%d bot=%d)",
+                        getName().c_str(), temp_top, temp_bot);
+                }
+            }
+
+            return reading;
+        },
+        2s
+    };
+};
+
+inline PeripheralFactory makeFactoryForSpadefootToadSensor() {
+    return makePeripheralFactory<
+        SpadefootToadSensor,
+        SpadefootToadSensorSettings,
+        api::ISoilMoistureSensor,
+        api::ITemperatureSensor>(
+        "soil:spadefoot-toad",
+        "environment",
+        [](PeripheralInitParameters& params, const std::shared_ptr<SpadefootToadSensorSettings>& settings) {
+            I2CConfig i2cConfig = settings->parse(0x20);
+            i2cConfig.clkSpeed = 100000;    // ATtiny TWI Address Match wakeup requires 100 kHz
+            auto sensor = std::make_shared<SpadefootToadSensor>(
+                params.name,
+                params.services.i2c,
+                i2cConfig);
+            params.registerFeature("moisture", [sensor](JsonObject& telemetryJson) {
+                telemetryJson["value"] = sensor->getMoisture();
+            });
+            params.registerFeature("temperature", [sensor](JsonObject& telemetryJson) {
+                telemetryJson["value"] = sensor->getTemperature();
+            });
+            return sensor;
+        });
+}
+
+}    // namespace cornucopia::ugly_duckling::peripherals::environment

--- a/config-templates/plot-controller-mk9-spadefoot-toad.json
+++ b/config-templates/plot-controller-mk9-spadefoot-toad.json
@@ -1,0 +1,45 @@
+{
+  "peripherals": [
+    {
+      "name": "flow-meter",
+      "type": "flow-meter",
+      "params": {
+        "pin": "IFLOWB"
+      }
+    },
+    {
+      "name": "valve",
+      "type": "valve",
+      "params": {
+        "motor": "b"
+      }
+    },
+    {
+      "name": "air",
+      "type": "environment:sht3x",
+      "params": {
+        "sda": "SDA",
+        "scl": "SCL"
+      }
+    },
+    {
+      "name": "soil",
+      "type": "soil:spadefoot-toad",
+      "params": {
+        "sda": "EXT_SDA",
+        "scl": "EXT_SCL"
+      }
+    }
+  ],
+  "functions": [
+    {
+      "name": "plot",
+      "type": "plot-controller",
+      "params": {
+        "flowMeter": "flow-meter",
+        "valve": "valve",
+        "soilMoistureSensor": "soil"
+      }
+    }
+  ]
+}

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,10 +1,31 @@
 # Architecture
 
+## System layers
+
+The firmware is organized into five conceptual layers, from low-level to high-level:
+
+```
+┌──────────────────────────────────────────┐
+│               Functions                  │  PlotController, ChickenDoor
+├──────────────────────────────────────────┤
+│              Peripherals                 │  Sensors, valves, motors, displays
+├──────────────────────────────────────────┤
+│          Peripheral factories            │  Create peripherals from JSON config
+├──────────────────────────────────────────┤
+│         Device (hardware model)          │  Pin assignments, on-board drivers
+├──────────────────────────────────────────┤
+│               Kernel                     │  WiFi, MQTT, NTP, Telemetry
+└──────────────────────────────────────────┘
+```
+
+## Kernel
+
+The kernel provides the shared runtime services every device relies on:
+
 ```mermaid
 graph BT
-    subgraph Kernel["Kernel"]
+    subgraph Kernel
         direction BT
-
         WiFi
         NetworkConnected(["Network connected"])
             style NetworkConnected stroke-width:4
@@ -12,72 +33,95 @@ graph BT
         RTCInSync(["RTC in sync"])
             style RTCInSync stroke-width:4
         MQTT
-        MQTTConnected(["MQTT\nconnected"])
+        MQTTConnected(["MQTT connected"])
             style MQTTConnected stroke-width:4
-        TelemetryManager["Telemetry\nManager"]
+        TelemetryManager["Telemetry Manager"]
 
         NetworkConnected --> WiFi
         MQTT -->|awaits| NetworkConnected
         MQTTConnected --> MQTT
         NTP -->|awaits| NetworkConnected
         RTCInSync -.->|provided by| NTP
-        RTCInSync -.->|provided by| PreBoot{{"Wake up from\nsleep"}}
+        RTCInSync -.->|provided by| PreBoot{{"Wake from sleep"}}
         TelemetryManager -->|awaits| MQTTConnected
         TelemetryManager -->|awaits| RTCInSync
     end
+```
 
-    subgraph ActualDeviceDefinition["Actual device definition"]
-        direction BT
+Key services:
 
-        subgraph BatteryDeviceDefinition["Battery-powered device definition"]
-            direction BT
-            %% We might have a device that has a battery or not
-            style BatteryDeviceDefinition stroke-dasharray: 4
+- **WiFi** — manages the station connection; publishes the `NetworkConnected` event.
+- **MQTT** — connects to the broker once the network is up; publishes `MQTTConnected`.
+- **NTP** — synchronizes the RTC after the network comes up.
+- **TelemetryManager** — collects telemetry from registered providers and publishes it once MQTT and the RTC are both ready.
+- **PowerManager** / **BatteryManager** — optional battery monitoring and sleep management.
+- **NVS** / **Configuration** — persistent key-value store for device and network config.
 
-            subgraph DeviceDefinition["Device definition"]
-                direction BT
+## Device (hardware model)
 
-                StatusLED["Status LED"]
-                PwmManager["PWM\nManager"]
-            end
+Each hardware revision is a concrete C++ class that:
 
-            Battery["Battery\n(service)"]
+- Declares pin assignments and on-board peripherals (status LED, PWM channels, I2C buses).
+- Registers a `BatteryManager` if the board has a battery.
+- Provides peripheral factories used by `PeripheralManager`.
 
-            Battery -.->|registers provider| TelemetryManager
-        end
+The active device class is selected at boot:
 
-        Drivers[["Drivers"]]
-        Services[["Services"]]
-        PeripheralFactories[["Peripheral\nFactories"]]
+1. **Compile-time override (`UD_GEN`)** — pass e.g. `-DMK7` to force a specific model; useful for Wokwi simulation.
+2. **Runtime MAC detection** — `main.cpp` checks the device MAC address prefix and instantiates the matching class.
+3. **Fallback** — `GenericDevice` is used with a warning if the MAC is not recognized.
 
-        Services -.->|uses| Drivers
-    end
+### Platform and model matrix
 
-    Drivers -.->|uses| PwmManager
+| Platform | ESP-IDF target | Models |
+| -------- | -------------- | ------ |
+| **Spinach** | `esp32s3` | MK5, MK6 (rev1–rev3), MK7, MK8 (rev1–rev2), MK9 rev1 |
+| **Carrot** | `esp32c6` | MK9 rev2 |
 
-    subgraph Device["Device"]
-        ConsolePrinter["Console Printer\n(debug)"]
-            style ConsolePrinter stroke-dasharray: 4
+Each platform produces a single firmware binary. The model and revision are reported in boot logs and in the MQTT `init` message.
 
-        Peripherals[["Peripherals"]]
-        PeripheralManager["Peripheral\nManager"]
-    end
+## Peripherals and functions
 
-    PeripheralManager -.->|"gets config from\n(when available)"| MQTT
-    PeripheralManager -.->|uses| PeripheralFactories
+See [Components.md](Components.md) for the full conceptual model. In brief:
 
-    PeripheralFactories -.->|knows\nabout| Services
-    PeripheralFactories -.->|creates| Peripherals
+- A **peripheral** is a physical element connected to the device (sensor, valve, motor).
+- A **function** is a logical grouping of peripherals that implements a real-world capability (e.g. `PlotController`, `ChickenDoor`).
+- `PeripheralManager` reads the device config from NVS and uses peripheral factories to instantiate peripherals at runtime. It also registers each peripheral as a telemetry provider with `TelemetryManager`.
 
-    PeripheralManager -.->|"registers\nprovider"| TelemetryManager
-    PeripheralManager -.->|"collects\ntelemetry"| Peripherals
+## Scheduling
 
-    Peripherals -.->|uses| Services
+The `scheduling` component contains independent scheduling strategies used by `PlotController`:
 
-    ConsolePrinter -.->|uses| WiFi
-    ConsolePrinter -.->|uses| Battery
+- `TimeBasedScheduler` — fixed daily schedule.
+- `MoistureBasedScheduler` — responds to soil moisture levels (optionally with a Kalman filter).
+- `LightSensorScheduler` — responds to ambient light (used by `ChickenDoor`).
+- `DelayScheduler` — simple delay-based control.
+- `CompositeScheduler` / `OverrideScheduler` — combine and override other schedulers.
 
-    Device o==o Kernel
-    Device o==o ActualDeviceDefinition
+## MQTT topic structure
 
+```
+/devices/ugly-duckling/$INSTANCE/          ← device root
+    init                                   ← boot announcement
+    telemetry                              ← periodic telemetry (all features)
+    commands/$COMMAND                      ← retained command messages
+    responses/$COMMAND                     ← command responses
+    peripheral/$PERIPHERAL_NAME/config     ← per-peripheral runtime config
+```
+
+## Component dependency graph
+
+```mermaid
+graph BT
+    kernel
+    devices -->|uses| kernel
+    peripherals-api
+    peripherals -->|implements| peripherals-api
+    peripherals -->|uses| kernel
+    scheduling
+    functions -->|uses| peripherals-api
+    functions -->|uses| scheduling
+    devices -->|knows about| peripherals
+    devices -->|knows about| functions
+    main -->|selects| devices
 ```

--- a/docs/CodingStandards.md
+++ b/docs/CodingStandards.md
@@ -1,0 +1,41 @@
+# Coding Standards
+
+## Formatting
+
+- Follow `.editorconfig`: LF line endings, UTF-8, 4-space indent (2 for JSON/YAML/Markdown/JS/TS).
+- C++ is formatted with a WebKit-flavored `.clang-format`: attached braces, left-aligned pointers (`int* p`), no single-line functions.
+- Run `clang-format` before committing; CI will reject misformatted code.
+
+## Static Analysis
+
+- Static analysis is via `.clang-tidy` with warnings-as-errors.
+- Regenerate the compile DB (needed after adding/removing files):
+
+  ```bash
+  python ./generate-clang-tidy-compile-db.py
+  ```
+
+- Run tidy manually:
+
+  ```bash
+  clang-tidy -p build/clang-tidy <file>
+  ```
+
+- CI runs clang-tidy on every build.
+
+## Naming Conventions
+
+| Kind | Convention | Example |
+| ---- | ---------- | ------- |
+| Types (classes, structs, enums) | PascalCase | `UglyDucklingMk6`, `PlotController` |
+| Functions and methods | camelCase | `startDevice()`, `getTemperature()` |
+| Constants and macros | UPPER_SNAKE | `UD_GEN`, `UD_DEBUG` |
+| Namespaces | compact, lowercase | `cornucopia::ugly_duckling::kernel` |
+
+## Markdown
+
+- Keep headings sequential (no skipped levels).
+- Lists must be properly indented; blank line before lists and headings.
+- Wrap all code examples in fenced code blocks with a language tag.
+- No trailing spaces; insert a final newline.
+- Follow markdownlint defaults.

--- a/docs/specs/Spadefoot-Toad-sensor.md
+++ b/docs/specs/Spadefoot-Toad-sensor.md
@@ -1,0 +1,290 @@
+# Spadefoot Toad Soil Sensor Implementation Plan
+
+## Overview
+
+Add support for the [Spadefoot Toad](https://github.com/cornucopia-machines/spadefoot-toad)
+capacitive soil sensor. The device is an ATtiny1616-based I2C slave that measures soil moisture and
+temperature at two depths (5 cm and 15 cm).
+
+Hardware layout:
+
+- **Four moisture electrode pairs**: TF (top-front), TR (top-rear), BF (bottom-front), BR (bottom-rear)
+- **Two NTC thermistors**: one at the top zone, one at the bottom zone
+
+We report:
+
+- One `"moisture"` feature — the mean of however many of the four moisture readings are valid (0xFF means
+  invalid/uncalibrated; exclude those from the average). Returns NaN if no valid reading exists.
+- One `"temperature"` feature — the mean of the two temperature readings, in °C. Returns NaN if the
+  temperature valid flag is not set or either reading is individually invalid.
+
+Calibration (CALIBRATE_DRY / CALIBRATE_WET) is permanently out of scope for this driver: calibration
+is performed by the manufacturer before the sensor ships. The driver never calibrates or reads raw values.
+
+## Device identifiers
+
+These are verified once during initialization. Log a warning and abort if any mismatches.
+
+| Command | Expected response | Meaning |
+| ------- | ----------------- | ------- |
+| `GET_MFR_ID` (`0xFE`) | `0x434D` (`"CM"` big-endian) | Manufacturer: Cornucopia Machines |
+| `GET_DEVICE_ID` (`0xFF`) | `0x0010` | Spadefoot Toad |
+| `GET_FIRMWARE_REV` (`0xFC`) | any `uint16_t` | Log at INFO level |
+| `GET_DEVICE_REV` (`0xFD`) | any `uint16_t` | Log at INFO level |
+
+All four are single-byte write transactions immediately followed by a two-byte read:
+
+```text
+master → [cmd_byte]       STOP
+master → repeated START (read direction)
+slave  → [MSB] [LSB]      STOP
+```
+
+## I2C constraints
+
+- **Speed: 100 kHz only.** The ATtiny TWI Address Match wakeup is incompatible with 400 kHz. This is a
+  hard constraint imposed by the device firmware — do not allow the caller to change it.
+- **Default address: `0x20`**, configurable via `SET_ADDRESS` (out of scope here).
+
+## Two-phase measurement protocol
+
+The sensor uses a two-phase protocol to avoid I2C timeouts during measurement:
+
+**Phase 1 — TRIGGER (`0x01`):** a write-only transaction. The ATtiny wakes, takes all
+measurements, stores results in RAM, and returns to sleep. No read follows.
+
+**Phase 2 — READ (`0x02`):** send the command byte, then read the 10-byte response. Must be
+issued at least 1 second after TRIGGER.
+
+```text
+Phase 1:   master → [0x01]  STOP
+           (wait ≥ 1 s)
+Phase 2:   master → [0x02]  STOP
+           master → (read 10 bytes)  STOP
+```
+
+`probe.py` waits 2 seconds between phases; 1 second is the documented minimum. Use 1 second in
+`DebouncedMeasurement` (the timer-based re-measurement already provides natural separation).
+
+## READ response packet (`0x02`) — 10 bytes
+
+```c
+struct SoilResponse {
+    uint8_t  moisture[4];  // [0]=TF, [1]=TR, [2]=BF, [3]=BR
+                           // 0–100 = percentage; 0xFF = invalid (not calibrated or timeout)
+    int16_t  temp_top;     // big-endian; units of 0.1 °C; INT16_MIN = invalid
+    int16_t  temp_bot;     // big-endian; units of 0.1 °C; INT16_MIN = invalid
+    uint8_t  flags;        // bit 0 = moisture valid, bit 1 = temperature valid
+    uint8_t  checksum;     // XOR of bytes [0..8]
+};
+```
+
+### Checksum
+
+XOR all nine bytes before the checksum byte. If the result does not equal `checksum`, discard the
+reading entirely and return NaN for both features.
+
+### Flags
+
+- **bit 0 (`MOISTURE_VALID`)**: if clear, all `moisture[]` bytes should be treated as invalid
+  regardless of their value.
+- **bit 1 (`TEMPERATURE_VALID`)**: if clear, both temperature readings are invalid and NaN is
+  reported for the temperature feature.
+
+Individual moisture entries with value `0xFF` are also invalid even when bit 0 is set (can happen
+when only some probes time out). Exclude them from the average.
+
+## Initialization sequence
+
+Performed once in the constructor, before the measurement loop starts:
+
+1. Write `GET_MFR_ID`, read 2 bytes → compare to `0x434D`. If mismatch: log error, throw exception.
+2. Write `GET_DEVICE_ID`, read 2 bytes → compare to `0x0010`. If mismatch: log error, throw exception.
+3. Write `GET_FIRMWARE_REV`, read 2 bytes → log as `"Spadefoot Toad firmware rev: 0x%04X"`.
+4. Write `GET_DEVICE_REV`, read 2 bytes → log as `"Spadefoot Toad device rev: 0x%04X"`.
+
+## Class design
+
+Follow the `ChirpSoilSensor` pattern closely: a single class implementing both
+`api::ISoilMoistureSensor` and `api::ITemperatureSensor`, backed by `DebouncedMeasurement`.
+
+New file: `components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp`
+
+```cpp
+class SpadefootToadSensorSettings
+    : public I2CSettings {
+    // No extra fields for now; I2C address comes from I2CSettings.
+};
+
+struct SpadefootToadReading {
+    double moisture    = std::numeric_limits<double>::quiet_NaN();
+    double temperature = std::numeric_limits<double>::quiet_NaN();
+};
+
+class SpadefootToadSensor final
+    : public api::ISoilMoistureSensor,
+      public api::ITemperatureSensor,
+      public Peripheral {
+public:
+    SpadefootToadSensor(
+        const std::string& name,
+        const std::shared_ptr<I2CManager>& i2c,
+        const I2CConfig& config);
+
+    Percent getMoisture() override;
+    Celsius getTemperature() override;
+
+private:
+    static constexpr uint8_t CMD_TRIGGER          = 0x01;
+    static constexpr uint8_t CMD_READ             = 0x02;
+    static constexpr uint8_t CMD_GET_FIRMWARE_REV = 0xFC;
+    static constexpr uint8_t CMD_GET_DEVICE_REV   = 0xFD;
+    static constexpr uint8_t CMD_GET_MFR_ID       = 0xFE;
+    static constexpr uint8_t CMD_GET_DEVICE_ID    = 0xFF;
+
+    static constexpr uint16_t EXPECTED_MFR_ID    = 0x434D;
+    static constexpr uint16_t EXPECTED_DEVICE_ID = 0x0010;
+
+    static constexpr uint8_t  FLAG_MOISTURE_VALID     = 0x01;
+    static constexpr uint8_t  FLAG_TEMPERATURE_VALID  = 0x02;
+    static constexpr uint8_t  MOISTURE_INVALID       = 0xFF;
+    static constexpr int16_t  TEMP_INVALID           = INT16_MIN;
+
+    const std::shared_ptr<I2CDevice> device;
+
+    utils::DebouncedMeasurement<SpadefootToadReading> measurement { /* see below */ };
+};
+```
+
+### Measurement lambda
+
+```cpp
+[this](const utils::DebouncedParams<SpadefootToadReading>) -> std::optional<SpadefootToadReading> {
+    // Phase 1: trigger
+    device->writeByte(CMD_TRIGGER);
+
+    // Phase 2: wait 1 s, then read
+    Task::delay(1s);
+    auto raw = device->readBytes(CMD_READ, 10);  // write CMD_READ, then read 10 bytes
+
+    // Validate checksum
+    uint8_t csum = 0;
+    for (int i = 0; i < 9; i++) csum ^= raw[i];
+    if (csum != raw[9]) {
+        LOGTW(ENV, "Spadefoot Toad '%s': checksum mismatch", name.c_str());
+        return std::nullopt;
+    }
+
+    SpadefootToadReading reading;
+    uint8_t flags = raw[8];
+
+    // Moisture: average of valid probes (flag bit 0 set and value != 0xFF)
+    if (flags & FLAG_MOISTURE_VALID) {
+        int sum = 0, count = 0;
+        for (int i = 0; i < 4; i++) {
+            if (raw[i] != MOISTURE_INVALID) {
+                sum += raw[i];
+                count++;
+            }
+        }
+        if (count > 0) {
+            reading.moisture = static_cast<double>(sum) / count;
+        }
+        LOGTV(ENV, "Spadefoot Toad '%s': moisture TF=%d TR=%d BF=%d BR=%d → avg=%.1f%%",
+            name.c_str(), raw[0], raw[1], raw[2], raw[3], reading.moisture);
+    }
+
+    // Temperature: average of top and bottom.
+    // Requires the temperature valid flag AND both individual readings to be valid.
+    if (flags & FLAG_TEMPERATURE_VALID) {
+        auto temp_top = static_cast<int16_t>((raw[4] << 8) | raw[5]);
+        auto temp_bot = static_cast<int16_t>((raw[6] << 8) | raw[7]);
+        if (temp_top != TEMP_INVALID && temp_bot != TEMP_INVALID) {
+            reading.temperature = (temp_top + temp_bot) / 20.0;  // two sensors, 0.1 °C units
+            LOGTV(ENV, "Spadefoot Toad '%s': temp top=%.1f°C bot=%.1f°C → avg=%.1f°C",
+                name.c_str(), temp_top / 10.0, temp_bot / 10.0, reading.temperature);
+        } else {
+            LOGTW(ENV, "Spadefoot Toad '%s': temperature valid flag set but individual reading(s) invalid (top=%d bot=%d)",
+                name.c_str(), temp_top, temp_bot);
+        }
+    }
+
+    return reading;
+}
+```
+
+The debounce interval is **2 seconds** — enough to cover the 1-second TRIGGER-to-READ wait plus
+measurement overhead.
+
+### I2C API additions
+
+The `I2CDevice` API currently exposes `readRegWord()` for 2-byte register reads. The Spadefoot Toad
+needs two additional methods; add them to `I2CDevice` if not already present:
+
+- **`writeByte(uint8_t cmd)`**: a write-only transaction — `[cmd] STOP` — with no subsequent read.
+  Used for TRIGGER.
+- **`readBytes(uint8_t cmd, size_t n)`**: write `[cmd]`, then read `n` bytes. Used for READ (10
+  bytes) and GET_* commands (2 bytes each). Whether this uses a repeated-start or a full
+  stop-start between the write and read is an implementation detail; the ATtiny should handle
+  both. Verify on real hardware during bringup.
+
+## Factory function
+
+```cpp
+inline PeripheralFactory makeFactoryForSpadefootToadSensor() {
+    return makePeripheralFactory<
+        SpadefootToadSensor,
+        SpadefootToadSensorSettings,
+        api::ISoilMoistureSensor,
+        api::ITemperatureSensor>(
+        "soil:spadefoot-toad",
+        "environment",
+        [](PeripheralInitParameters& params, const std::shared_ptr<SpadefootToadSensorSettings>& settings) {
+            I2CConfig i2cConfig = settings->parse(0x20);
+            auto sensor = std::make_shared<SpadefootToadSensor>(
+                params.name,
+                params.services.i2c,
+                i2cConfig);
+            params.registerFeature("moisture", [sensor](JsonObject& telemetryJson) {
+                telemetryJson["value"] = sensor->getMoisture();
+            });
+            params.registerFeature("temperature", [sensor](JsonObject& telemetryJson) {
+                telemetryJson["value"] = sensor->getTemperature();
+            });
+            return sensor;
+        });
+}
+```
+
+## Registering the factory
+
+In `DeviceDefinition.hpp` (or whichever device header is appropriate):
+
+```cpp
+#include <peripherals/environment/SpadefootToadSensor.hpp>
+// ...
+peripheralManager->registerFactory(environment::makeFactoryForSpadefootToadSensor());
+```
+
+## JSON configuration example
+
+```jsonc
+{
+  "type": "soil:spadefoot-toad",
+  "name": "bed-soil",
+  "params": {
+    "address": "0x20",
+    "sda": "GPIO4",
+    "scl": "GPIO5"
+  }
+}
+```
+
+## Open questions
+
+1. **I2C clock speed**: confirm the `I2CConfig`/`I2CManager` path that enforces 100 kHz. If the bus
+   is shared with other peripherals running at 400 kHz, the Spadefoot Toad will need its own
+   dedicated I2C bus.
+2. **Stop-vs-repeated-start for `readBytes`**: the `probe.py` reference tool uses a full stop
+   between the command write and the data read. Verify that the ATtiny handles repeated-start
+   equally well during bringup, in case the ESP-IDF I2C driver combines them.


### PR DESCRIPTION
Fixes #541

Related: https://github.com/cornucopia-machines/spadefoot-toad/pull/1

## Changes

### New: `SpadefootToadSensor` (`components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp`)

Implements the [Spadefoot Toad](https://github.com/cornucopia-machines/spadefoot-toad) capacitive soil sensor (ATtiny1616-based I2C slave, address `0x20`).

- Implements both `ISoilMoistureSensor` and `ITemperatureSensor`, following the `ChirpSoilSensor` pattern
- **Initialization**: verifies manufacturer ID (`0x434D`) and device ID (`0x0010`) on construction, throwing on mismatch; logs firmware and device revision
- **Measurement**: two-phase protocol — sends `TRIGGER` (`0x01`), waits 1 s, reads 10-byte response via `READ` (`0x02`); validates XOR checksum over bytes 0–8
- **Moisture**: mean of up to four probe readings (TF/TR/BF/BR), excluding `0xFF` (invalid) entries and gated by flag bit 0; returns NaN if no valid reading
- **Temperature**: mean of top and bottom NTC readings in 0.1 °C units, gated by flag bit 1 and both readings non-`INT16_MIN`; returns NaN otherwise
- **Debounce interval**: 2 s (covers the 1 s trigger-to-read wait)
- **Clock speed**: enforced at 100 kHz (ATtiny TWI Address Match wakeup constraint) regardless of JSON config
- Registered as `"soil:spadefoot-toad"` in `DeviceDefinition.hpp`

### `I2CDevice`: two new methods

- `writeByte(uint8_t cmd)` — write-only transaction (`[cmd] STOP`), used for `TRIGGER`
- `readBytes(uint8_t cmd, size_t n)` — writes `cmd` then reads `n` bytes into a `std::vector<uint8_t>`, used for `READ` and (via `readRegWord`) the `GET_*` init commands

### `I2CConfig` / `I2CManager`: configurable clock speed

- Added `clkSpeed` field to `I2CConfig` (Hz, default 400 kHz); threaded through `I2CManager::createDevice` and `I2CDevice` constructor
- The existing pin-based `createDevice` overload keeps its 400 kHz default (was 200 kHz — not a standard I2C speed)

### `I2CSettings`: `clkSpeed` JSON property

- Added `clkSpeed` property (unit: **kHz**, default `400`); `parse()` converts to Hz for `I2CConfig`
- Example: `"clkSpeed": 100` for Standard Mode devices

## Testing

Tested on hardware with a Spadefoot Toad MK1 sensor. Root cause of initial `ESP_ERR_INVALID_RESPONSE` was the I2C bus running at 200 kHz — above the ATtiny's 100 kHz limit.

## Config example

```jsonc
{
  "type": "soil:spadefoot-toad",
  "name": "bed-soil",
  "params": {
    "sda": "EXT_SDA",
    "scl": "EXT_SCL"
  }
}
```

`address` (default `0x20`) and `clkSpeed` (ignored — enforced at 100 kHz) can be specified but are optional.