### PR TITLE
Add calibration commands to Spadefoot Toad driver

### DIFF
--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -469,7 +469,7 @@ static void startDevice() {
     // Init peripherals
     auto peripheralServices = PeripheralServices {
         .i2c = i2c,
-        .mqttRoot = mqttRoot,
+        .mqttDeviceRoot = mqttRoot,
         .nvs = peripheralsNvs,
         .pcntManager = pcnt,
         .pulseCounterManager = pulseCounterManager,

--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -469,6 +469,7 @@ static void startDevice() {
     // Init peripherals
     auto peripheralServices = PeripheralServices {
         .i2c = i2c,
+        .mqttRoot = mqttRoot,
         .nvs = peripheralsNvs,
         .pcntManager = pcnt,
         .pulseCounterManager = pulseCounterManager,
@@ -484,8 +485,8 @@ static void startDevice() {
 
     // Init functions
     auto functionServices = FunctionServices {
-        .telemetryPublisher = telemetryPublisher,
         .peripherals = peripheralManager,
+        .telemetryPublisher = telemetryPublisher,
     };
     auto functionsConfigNvs = std::make_shared<NvsStore>("function-cfg");
     auto functionManager = std::make_shared<FunctionManager>(functionsConfigNvs, functionServices, mqttRoot);

--- a/components/functions/src/functions/Function.hpp
+++ b/components/functions/src/functions/Function.hpp
@@ -18,14 +18,22 @@ struct FunctionServices {
 };
 
 struct FunctionInitParameters {
-    const std::string name;
-    const FunctionServices& services;
-    const std::shared_ptr<MqttRoot> mqttRoot;
+    std::shared_ptr<MqttRoot> functionRoot() {
+        if (!mqttFunctionRoot) {
+            mqttFunctionRoot = mqttDeviceRoot->forSuffix("functions/" + name);
+        }
+        return mqttFunctionRoot;
+    }
 
     template <typename T>
     std::shared_ptr<T> peripheral(const std::string& name) const {
         return services.peripherals->getPeripheral<T>(name);
     }
+
+    const std::string name;
+    const FunctionServices& services;
+    const std::shared_ptr<MqttRoot> mqttDeviceRoot;
+    std::shared_ptr<MqttRoot> mqttFunctionRoot;
 };
 
 using FunctionCreateFn = std::function<Handle(
@@ -83,7 +91,7 @@ FunctionFactory makeFunctionFactory(
                 std::static_pointer_cast<HasConfig<TConfig>>(impl)->configure(config);
 
                 // Subscribe for config updates
-                params.mqttRoot->subscribe("config", [name = params.name, nvsConfig, impl](const std::string&, const JsonObject& cfgJson) {
+                params.functionRoot()->subscribe("config", [name = params.name, nvsConfig, impl](const std::string&, const JsonObject& cfgJson) {
                     LOGD("Received configuration update for function: %s", name.c_str());
                     try {
                         nvsConfig->update(cfgJson);
@@ -123,7 +131,7 @@ public:
                     FunctionInitParameters params = {
                         .name = name,
                         .services = services,
-                        .mqttRoot = mqttDeviceRoot->forSuffix("functions/" + name),
+                        .mqttDeviceRoot = mqttDeviceRoot,
                     };
                     JsonObject initConfigJson = initJson["config"].to<JsonObject>();
                     return factory.create(params, nvs, settings, initConfigJson);

--- a/components/functions/src/functions/Function.hpp
+++ b/components/functions/src/functions/Function.hpp
@@ -11,9 +11,10 @@ using cornucopia::ugly_duckling::peripherals::PeripheralManager;
 
 namespace cornucopia::ugly_duckling::functions {
 
+// Fields are kept in alphabetical order — please maintain this when adding new entries.
 struct FunctionServices {
-    const std::shared_ptr<TelemetryPublisher> telemetryPublisher;
     const std::shared_ptr<PeripheralManager> peripherals;
+    const std::shared_ptr<TelemetryPublisher> telemetryPublisher;
 };
 
 struct FunctionInitParameters {

--- a/components/kernel/src/mqtt/MqttRoot.hpp
+++ b/components/kernel/src/mqtt/MqttRoot.hpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include <mqtt/MqttDriver.hpp>
 #include <utility>
@@ -27,13 +28,22 @@ public:
                     publish("responses/" + command, responseDoc, Retention::NoRetain, QoS::ExactlyOnce);
                 }
             } else {
-                LOGTE(MQTT, "Unknown command: %s", command.c_str());
+                std::string knownCommands;
+                for (const auto& [name, _] : commandHandlers) {
+                    if (!knownCommands.empty()) {
+                        knownCommands += ", ";
+                    }
+                    knownCommands += name;
+                }
+                LOGTE(MQTT, "Unknown command: %s (known: %s)", command.c_str(), knownCommands.c_str());
             }
         });
     }
 
     std::shared_ptr<MqttRoot> forSuffix(const std::string& suffix) {
-        return std::make_shared<MqttRoot>(mqtt, rootTopic + "/" + suffix);
+        auto child = std::make_shared<MqttRoot>(mqtt, rootTopic + "/" + suffix);
+        children.push_back(child);
+        return child;
     }
 
     PublishStatus publish(const std::string& suffix, const JsonDocument& json, Retention retain = Retention::NoRetain, QoS qos = QoS::AtMostOnce, ticks timeout = MqttDriver::MQTT_NETWORK_TIMEOUT, LogPublish log = LogPublish::Log) {
@@ -77,6 +87,7 @@ private:
 
     const std::string rootTopic;
     std::unordered_map<std::string, CommandHandler> commandHandlers;
+    std::vector<std::shared_ptr<MqttRoot>> children;
 };
 
 }    // namespace cornucopia::ugly_duckling::kernel::mqtt

--- a/components/peripherals/src/peripherals/Peripheral.hpp
+++ b/components/peripherals/src/peripherals/Peripheral.hpp
@@ -47,7 +47,7 @@ public:
 // Fields are kept in alphabetical order — please maintain this when adding new entries.
 struct PeripheralServices {
     const std::shared_ptr<I2CManager> i2c;
-    const std::shared_ptr<mqtt::MqttRoot> mqttRoot;
+    const std::shared_ptr<mqtt::MqttRoot> mqttDeviceRoot;
     const std::shared_ptr<NvsStore> nvs;
     const std::shared_ptr<PcntManager> pcntManager;
     const std::shared_ptr<PulseCounterManager> pulseCounterManager;
@@ -71,7 +71,7 @@ struct PeripheralInitParameters {
 
     std::shared_ptr<mqtt::MqttRoot> peripheralRoot() {
         if (!mqttPeripheralRoot) {
-            mqttPeripheralRoot = services.mqttRoot->forSuffix("peripherals/" + name);
+            mqttPeripheralRoot = services.mqttDeviceRoot->forSuffix("peripherals/" + name);
         }
         return mqttPeripheralRoot;
     }

--- a/components/peripherals/src/peripherals/Peripheral.hpp
+++ b/components/peripherals/src/peripherals/Peripheral.hpp
@@ -17,6 +17,7 @@
 #include <PwmManager.hpp>
 #include <Telemetry.hpp>
 #include <drivers/SwitchManager.hpp>
+#include <mqtt/MqttRoot.hpp>
 
 #include <peripherals/api/IPeripheral.hpp>
 
@@ -43,8 +44,10 @@ public:
 
 // Peripheral factories
 
+// Fields are kept in alphabetical order — please maintain this when adding new entries.
 struct PeripheralServices {
     const std::shared_ptr<I2CManager> i2c;
+    const std::shared_ptr<mqtt::MqttRoot> mqttRoot;
     const std::shared_ptr<NvsStore> nvs;
     const std::shared_ptr<PcntManager> pcntManager;
     const std::shared_ptr<PulseCounterManager> pulseCounterManager;
@@ -66,6 +69,13 @@ struct PeripheralInitParameters {
         features.add(type);
     }
 
+    void registerCommand(const std::string& command, const mqtt::CommandHandler& handler) {
+        if (!peripheralMqttRoot) {
+            peripheralMqttRoot = services.mqttRoot->forSuffix("peripherals/" + name);
+        }
+        peripheralMqttRoot->registerCommand(command, handler);
+    }
+
     template <typename T>
     std::shared_ptr<T> peripheral(const std::string& name) const {
         return peripherals.getInstance<T>(name);
@@ -77,6 +87,7 @@ struct PeripheralInitParameters {
     const JsonArray features;
 
     Manager<PeripheralFactory>& peripherals;
+    std::shared_ptr<mqtt::MqttRoot> peripheralMqttRoot;
 };
 
 // Helper to build a PeripheralFactory while keeping strong types for settings/config.

--- a/components/peripherals/src/peripherals/Peripheral.hpp
+++ b/components/peripherals/src/peripherals/Peripheral.hpp
@@ -69,11 +69,11 @@ struct PeripheralInitParameters {
         features.add(type);
     }
 
-    void registerCommand(const std::string& command, const mqtt::CommandHandler& handler) {
-        if (!peripheralMqttRoot) {
-            peripheralMqttRoot = services.mqttRoot->forSuffix("peripherals/" + name);
+    std::shared_ptr<mqtt::MqttRoot> peripheralRoot() {
+        if (!mqttPeripheralRoot) {
+            mqttPeripheralRoot = services.mqttRoot->forSuffix("peripherals/" + name);
         }
-        peripheralMqttRoot->registerCommand(command, handler);
+        return mqttPeripheralRoot;
     }
 
     template <typename T>
@@ -87,7 +87,7 @@ struct PeripheralInitParameters {
     const JsonArray features;
 
     Manager<PeripheralFactory>& peripherals;
-    std::shared_ptr<mqtt::MqttRoot> peripheralMqttRoot;
+    std::shared_ptr<mqtt::MqttRoot> mqttPeripheralRoot;
 };
 
 // Helper to build a PeripheralFactory while keeping strong types for settings/config.

--- a/components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp
@@ -21,6 +21,11 @@ using namespace cornucopia::ugly_duckling::peripherals;
 
 namespace cornucopia::ugly_duckling::peripherals::environment {
 
+enum class CalibrationReference : uint8_t {
+    Dry,
+    Wet,
+};
+
 class SpadefootToadSensorSettings
     : public I2CSettings {
 public:
@@ -98,11 +103,48 @@ public:
         return measurement.getValue().temperature;
     }
 
+    void calibrate(CalibrationReference ref) {
+        uint8_t cmd = (ref == CalibrationReference::Wet) ? CMD_CALIBRATE_WET : CMD_CALIBRATE_DRY;
+        LOGTI(ENV, "Spadefoot Toad '%s': calibrating %s reference",
+            getName().c_str(), ref == CalibrationReference::Wet ? "wet" : "dry");
+        device->writeByte(cmd);
+    }
+
+    void readCalibration(JsonObject& res) {
+        auto calibration = device->readBytes(CMD_READ_CALIBRATION, 17);
+        uint8_t csum = 0;
+        for (int i = 0; i < 16; i++) {
+            csum ^= calibration[i];
+        }
+        if (csum != calibration[16]) {
+            res["checksumOk"] = false;
+            return;
+        }
+        res["checksumOk"] = true;
+        static constexpr const char* PROBE_NAMES[] = { "top-front", "top-rear", "bottom-front", "bottom-rear" };
+        for (int i = 0; i < 4; i++) {
+            uint16_t dryVal = static_cast<uint16_t>((calibration[i * 2] << 8) | calibration[i * 2 + 1]);
+            uint16_t wetVal = static_cast<uint16_t>((calibration[8 + i * 2] << 8) | calibration[8 + i * 2 + 1]);
+            auto probeObj = res[PROBE_NAMES[i]].to<JsonObject>();
+            probeObj["dry"] = dryVal;
+            probeObj["wet"] = wetVal;
+        }
+    }
+
+    void factoryReset() {
+        LOGTW(ENV, "Spadefoot Toad '%s': factory reset issued", getName().c_str());
+        device->writeByte(CMD_FACTORY_RESET);
+    }
+
 private:
+    // Command bytes are kept in numerical order — please maintain this when adding new entries.
     static constexpr uint8_t CMD_TRIGGER = 0x01;
     static constexpr uint8_t CMD_READ = 0x02;
     static constexpr uint8_t CMD_READ_RAW = 0x03;
+    static constexpr uint8_t CMD_CALIBRATE_DRY = 0x04;
+    static constexpr uint8_t CMD_CALIBRATE_WET = 0x05;
     static constexpr uint8_t CMD_READ_CALIBRATION = 0x06;
+    static constexpr uint8_t CMD_FACTORY_RESET = 0xFB;
     static constexpr uint8_t CMD_GET_FIRMWARE_REV = 0xFC;
     static constexpr uint8_t CMD_GET_DEVICE_REV = 0xFD;
     static constexpr uint8_t CMD_GET_MFR_ID = 0xFE;
@@ -175,7 +217,7 @@ private:
                 if (count > 0) {
                     reading.moisture = static_cast<double>(sum) / count;
                 }
-                LOGTV(ENV, "Spadefoot Toad '%s': moisture TF=%d TR=%d BF=%d BR=%d → avg=%.1f%%",
+                LOGTI(ENV, "Spadefoot Toad '%s': moisture TF=%d TR=%d BF=%d BR=%d → avg=%.1f%%",
                     getName().c_str(), data[0], data[1], data[2], data[3], reading.moisture);
             }
 
@@ -186,7 +228,7 @@ private:
                 auto temp_bot = static_cast<int16_t>((data[6] << 8) | data[7]);
                 if (temp_top != TEMP_INVALID && temp_bot != TEMP_INVALID) {
                     reading.temperature = (temp_top + temp_bot) / 20.0;    // two sensors, 0.1 °C units
-                    LOGTV(ENV, "Spadefoot Toad '%s': temp top=%.1f°C bot=%.1f°C → avg=%.1f°C",
+                    LOGTI(ENV, "Spadefoot Toad '%s': temp top=%.1f°C bot=%.1f°C → avg=%.1f°C",
                         getName().c_str(), temp_top / 10.0, temp_bot / 10.0, reading.temperature);
                 } else {
                     LOGTW(ENV, "Spadefoot Toad '%s': temperature valid flag set but individual reading(s) invalid (top=%d bot=%d)",
@@ -222,8 +264,47 @@ inline PeripheralFactory makeFactoryForSpadefootToadSensor() {
             params.registerFeature("temperature", [sensor](JsonObject& telemetryJson) {
                 telemetryJson["value"] = sensor->getTemperature();
             });
+            params.registerCommand("calibrate", [sensor](const JsonObject& req, JsonObject&) {
+                auto ref = req["reference"].as<CalibrationReference>();
+                sensor->calibrate(ref);
+            });
+            params.registerCommand("read-calibration", [sensor](const JsonObject&, JsonObject& res) {
+                sensor->readCalibration(res);
+            });
+            params.registerCommand("factory-reset", [sensor](const JsonObject&, JsonObject&) {
+                sensor->factoryReset();
+            });
             return sensor;
         });
 }
 
 }    // namespace cornucopia::ugly_duckling::peripherals::environment
+
+namespace ArduinoJson {
+
+using cornucopia::ugly_duckling::peripherals::environment::CalibrationReference;
+
+template <>
+struct Converter<CalibrationReference> {
+    static bool toJson(const CalibrationReference& src, JsonVariant dst) {
+        switch (src) {
+            case CalibrationReference::Dry: return dst.set("dry");
+            case CalibrationReference::Wet: return dst.set("wet");
+        }
+        return false;
+    }
+
+    static CalibrationReference fromJson(JsonVariantConst src) {
+        std::string s = src.as<std::string>();
+        if (s == "wet") return CalibrationReference::Wet;
+        return CalibrationReference::Dry;    // default / unknown → Dry
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        if (!src.is<const char*>()) return false;
+        std::string s = src.as<std::string>();
+        return s == "dry" || s == "wet";
+    }
+};
+
+}    // namespace ArduinoJson

--- a/components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp
@@ -264,14 +264,14 @@ inline PeripheralFactory makeFactoryForSpadefootToadSensor() {
             params.registerFeature("temperature", [sensor](JsonObject& telemetryJson) {
                 telemetryJson["value"] = sensor->getTemperature();
             });
-            params.registerCommand("calibrate", [sensor](const JsonObject& req, JsonObject&) {
+            params.peripheralRoot()->registerCommand("calibrate", [sensor](const JsonObject& req, JsonObject&) {
                 auto ref = req["reference"].as<CalibrationReference>();
                 sensor->calibrate(ref);
             });
-            params.registerCommand("read-calibration", [sensor](const JsonObject&, JsonObject& res) {
+            params.peripheralRoot()->registerCommand("read-calibration", [sensor](const JsonObject&, JsonObject& res) {
                 sensor->readCalibration(res);
             });
-            params.registerCommand("factory-reset", [sensor](const JsonObject&, JsonObject&) {
+            params.peripheralRoot()->registerCommand("factory-reset", [sensor](const JsonObject&, JsonObject&) {
                 sensor->factoryReset();
             });
             return sensor;

--- a/docs/specs/Spadefoot-Toad-calibration-commands.md
+++ b/docs/specs/Spadefoot-Toad-calibration-commands.md
@@ -1,0 +1,264 @@
+# Spadefoot Toad: Calibration Commands
+
+## Overview
+
+Add three admin-facing MQTT commands to the Spadefoot Toad driver, enabling factory calibration
+from the field without a dedicated programmer tool:
+
+| Command            | Payload                           | Response              |
+| ------------------ | --------------------------------- | --------------------- |
+| `calibrate`        | `{ "reference": "dry" \| "wet" }` | _(none)_              |
+| `read-calibration` | _(none)_                          | calibration data JSON |
+| `factory-reset`    | _(none)_                          | _(none)_              |
+
+Commands arrive via MQTT at `devices/<device-id>/peripherals/<name>/commands/<command>` and are
+dispatched through the existing `MqttRoot` command-handler mechanism.
+
+## Infrastructure: peripheral command registration
+
+### 1. Add `mqttRoot` to `PeripheralServices`
+
+`PeripheralServices` (in `Peripheral.hpp`) gains one new field:
+
+```cpp
+struct PeripheralServices {
+    // ... existing fields ...
+    const std::shared_ptr<mqtt::MqttRoot> mqttRoot;
+};
+```
+
+In `Device.hpp`, populate it when constructing `PeripheralServices`:
+
+```cpp
+auto peripheralServices = PeripheralServices {
+    // ... existing fields ...
+    .mqttRoot = mqttRoot,
+};
+```
+
+### 2. Extend `PeripheralInitParameters`
+
+Add a `registerCommand()` method. It lazily constructs a peripheral-scoped `MqttRoot` under
+`peripherals/<name>` the first time a command is registered, then delegates to it:
+
+```cpp
+struct PeripheralInitParameters {
+    // ... existing public members and registerFeature() ...
+
+    void registerCommand(const std::string& command, const mqtt::CommandHandler& handler) {
+        if (!peripheralMqttRoot) {
+            peripheralMqttRoot = services.mqttRoot->forSuffix("peripherals/" + name);
+        }
+        peripheralMqttRoot->registerCommand(command, handler);
+    }
+
+    // ... existing fields ...
+
+private:
+    std::shared_ptr<mqtt::MqttRoot> peripheralMqttRoot;   // null until first registerCommand()
+};
+```
+
+`services.mqttRoot` is the device-level `MqttRoot` already stored in `PeripheralServices`.
+No change is needed in `PeripheralManager::createPeripheral` — `services` is already forwarded.
+
+#### MQTT topic layout
+
+```text
+devices/<device-id>/peripherals/<name>/commands/<command>   ← incoming request
+devices/<device-id>/peripherals/<name>/responses/<command>  ← response (if non-empty)
+```
+
+These are the standard topic patterns established by `MqttRoot::registerCommand()` and
+`MqttRoot::forSuffix()` — no new convention is introduced.
+
+### 3. Header includes
+
+`Peripheral.hpp` will need:
+
+```cpp
+#include <mqtt/MqttRoot.hpp>
+```
+
+## `CalibrationReference` enum
+
+Introduce a scoped enum in the `environment` namespace (same file as `SpadefootToadSensor`):
+
+```cpp
+enum class CalibrationReference : uint8_t {
+    Dry,
+    Wet,
+};
+```
+
+Provide ArduinoJSON string serialization in the `ArduinoJson` namespace (after the class
+definition, following the same pattern used by `OperationState` in `Door.hpp`):
+
+```cpp
+namespace ArduinoJson {
+
+using cornucopia::ugly_duckling::peripherals::environment::CalibrationReference;
+
+template <>
+struct Converter<CalibrationReference> {
+    static bool toJson(const CalibrationReference& src, JsonVariant dst) {
+        switch (src) {
+            case CalibrationReference::Dry: return dst.set("dry");
+            case CalibrationReference::Wet: return dst.set("wet");
+        }
+        return false;
+    }
+
+    static CalibrationReference fromJson(JsonVariantConst src) {
+        std::string s = src.as<std::string>();
+        if (s == "wet") return CalibrationReference::Wet;
+        return CalibrationReference::Dry;    // default / unknown → Dry
+    }
+
+    static bool checkJson(JsonVariantConst src) {
+        if (!src.is<const char*>()) return false;
+        std::string s = src.as<std::string>();
+        return s == "dry" || s == "wet";
+    }
+};
+
+}    // namespace ArduinoJson
+```
+
+## Spadefoot Toad hardware protocol (calibration commands)
+
+| Command            | Byte   | Direction  | Notes                                                        |
+| ------------------ | ------ | ---------- | ------------------------------------------------------------ |
+| `CALIBRATE_DRY`    | `0x04` | write-only | Takes an immediate internal measurement; stores to EEPROM    |
+| `CALIBRATE_WET`    | `0x05` | write-only | Takes an immediate internal measurement; stores to EEPROM    |
+| `READ_CALIBRATION` | `0x06` | write+read | Already implemented; reads 17 bytes                          |
+| `FACTORY_RESET`    | `0xFB` | write-only | Wipes calibration and resets I2C address to `0x20` in EEPROM |
+
+`CALIBRATE_DRY` and `CALIBRATE_WET` do **not** reuse the last TRIGGER result — the ATtiny takes a
+fresh internal measurement at the moment the command is received and writes those raw tick counts
+directly to EEPROM.
+
+All write-only transactions follow the TRIGGER pattern (`[cmd] STOP`, no subsequent read).
+`READ_CALIBRATION` uses the same write-then-read pattern as `CMD_READ`.
+
+Add the new command byte constants to `SpadefootToadSensor`:
+
+```cpp
+static constexpr uint8_t CMD_CALIBRATE_DRY = 0x04;
+static constexpr uint8_t CMD_CALIBRATE_WET = 0x05;
+static constexpr uint8_t CMD_FACTORY_RESET = 0xFB;
+// CMD_READ_CALIBRATION = 0x06 already present
+```
+
+## MQTT commands
+
+All three commands are registered in the factory lambda, after the sensor is constructed:
+
+```cpp
+auto sensor = std::make_shared<SpadefootToadSensor>(...);
+
+params.registerFeature("moisture", ...);
+params.registerFeature("temperature", ...);
+
+params.registerCommand("calibrate", [sensor](const JsonObject& req, JsonObject&) {
+    auto ref = req["reference"].as<CalibrationReference>();
+    sensor->calibrate(ref);
+});
+
+params.registerCommand("read-calibration", [sensor](const JsonObject&, JsonObject& res) {
+    sensor->readCalibration(res);
+});
+
+params.registerCommand("factory-reset", [sensor](const JsonObject&, JsonObject&) {
+    sensor->factoryReset();
+});
+```
+
+### `calibrate`
+
+**Request:** `{ "reference": "dry" }` or `{ "reference": "wet" }`
+
+**Response:** none (empty `JsonObject` → no response published)
+
+**Behavior:**
+
+1. Select `CMD_CALIBRATE_DRY` or `CMD_CALIBRATE_WET` based on `reference`.
+2. Send a write-only I2C transaction: `[cmd] STOP`.
+3. Log at INFO: `"Spadefoot Toad '%s': calibrating %s reference"`.
+
+The ATtiny takes a fresh internal measurement immediately on receiving the command and writes the
+raw tick counts to EEPROM — it does **not** reuse the last TRIGGER result.
+
+```cpp
+void calibrate(CalibrationReference ref) {
+    uint8_t cmd = (ref == CalibrationReference::Wet) ? CMD_CALIBRATE_WET : CMD_CALIBRATE_DRY;
+    LOGTI(ENV, "Spadefoot Toad '%s': calibrating %s reference",
+        getName().c_str(), ref == CalibrationReference::Wet ? "wet" : "dry");
+    device->writeByte(cmd);
+}
+```
+
+### `read-calibration`
+
+**Request:** _(empty payload)_
+
+**Response:**
+
+```jsonc
+{
+  "checksumOk": true,
+  "top-front":    { "dry": 1234, "wet": 5678 },
+  "top-rear":     { "dry": 1234, "wet": 5678 },
+  "bottom-front": { "dry": 1234, "wet": 5678 },
+  "bottom-rear":  { "dry": 1234, "wet": 5678 },
+}
+```
+
+Values of `0xFFFF` indicate that the corresponding reference has not yet been calibrated.
+If the checksum does not match, return `{ "checksumOk": false }` with no probe fields.
+
+**Behavior:** issue `CMD_READ_CALIBRATION`, read 17 bytes, verify XOR checksum (same logic
+already present in the constructor), populate response JSON.
+
+### `factory-reset`
+
+**Request:** _(empty payload)_
+
+**Response:** none
+
+**Behavior:** send `CMD_FACTORY_RESET` as a write-only I2C transaction. The ATtiny wipes all
+calibration slots to `0xFFFF` and resets the I2C address to `0x20` in EEPROM; the new address
+takes effect after the next ATtiny reset. Log at WARN:
+`"Spadefoot Toad '%s': factory reset issued"`.
+
+```cpp
+void factoryReset() {
+    LOGTW(ENV, "Spadefoot Toad '%s': factory reset issued", getName().c_str());
+    device->writeByte(CMD_FACTORY_RESET);
+}
+```
+
+## Changes to `SpadefootToadSensor.hpp`
+
+Summary of all additions to the class:
+
+- Three new `CMD_*` constants (`0x04`, `0x05`, `0xFB`).
+- Three new public methods: `calibrate()`, `readCalibration()`, `factoryReset()`.
+- `SpadefootToadSensorSettings` gains no new fields (no new configuration).
+- `CalibrationReference` enum + `ArduinoJson::Converter<CalibrationReference>` added in the same file.
+- Factory lambda gains three `params.registerCommand(...)` calls.
+
+## Constructor calibration logging
+
+The existing constructor already reads and logs calibration data. Keep this behaviour unchanged —
+it provides a useful baseline snapshot in the boot log. The new `read-calibration` command is an
+on-demand read for interactive use.
+
+## Open questions
+
+1. **Calibration timing** — `CALIBRATE_DRY`/`WET` take an internal measurement synchronously
+   before returning. Does the ATtiny need any additional settling time after the EEPROM write
+   before normal TRIGGER measurements can safely resume? If so, should the driver insert a delay
+   or just rely on the natural measurement cadence?
+2. **Access control** — MQTT command access control (admin-only) is enforced at the broker layer,
+   not in the firmware. Document this expectation in the admin tooling, not here.


### PR DESCRIPTION
- Register calibrate, read-calibration, and factory-reset MQTT commands
  on the peripheral-scoped topic (peripherals/<name>/commands/<command>)
- Add PeripheralInitParameters::registerCommand() which lazily creates a
  peripheral-scoped MqttRoot via forSuffix() on first use
- Add mqttRoot to PeripheralServices (and wire it up in Device.hpp)
- Fix MqttRoot::forSuffix() to retain child roots, preventing
  use-after-free when the caller does not hold onto the returned ptr
- Add CalibrationReference enum with ArduinoJson converter
- Promote individual moisture/temperature log lines from VERBOSE to INFO
- Keep PeripheralServices and FunctionServices fields alphabetically
  ordered (with comments to maintain the invariant)
- Keep CMD_* constants in numerical order (with comment)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>