### PR TITLE
i2c: Full LP_I2C support for MK11+ (fix i2cdev clock source, remove preInstallIfLp)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           extra_docker_args: -v  ${{ env.CCACHE_DIR }}:/root/.ccache
           command: |
             ccache --max-size=${{ env.CCACHE_MAXSIZE }} && \
-            run-clang-tidy -p build/clang -header-filter="$(pwd)/(main|components/(?![^/]*__))" $(find main components -type f -name '*.cpp' -not -path '*/test/*' -not -path '*/build/*' -not -path '*/__*')
+            run-clang-tidy -p build/clang -header-filter="$(pwd)/(main|components)/" $(find main components -type f -name '*.cpp' -not -path '*/test/*' -not -path '*/build/*')
 
       - name: Collect artifacts
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           extra_docker_args: -v  ${{ env.CCACHE_DIR }}:/root/.ccache
           command: |
             ccache --max-size=${{ env.CCACHE_MAXSIZE }} && \
-            run-clang-tidy -p build/clang -header-filter="$(pwd)/(main|components)/" $(find main components -type f -name '*.cpp' -not -path '*/test/*' -not -path '*/build/*')
+            run-clang-tidy -p build/clang -header-filter="$(pwd)/(main|components/(?![^/]*__))" $(find main components -type f -name '*.cpp' -not -path '*/test/*' -not -path '*/build/*' -not -path '*/__*')
 
       - name: Collect artifacts
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 
 # ESP-IDF generated files
 build/
+# Alternative build directories for platforms and for tests
+build-*/
 
 sdkconfig*
 !sdkconfig*.defaults
@@ -28,12 +30,6 @@ warnings.txt
 # Python cache files
 __pycache__/
 .pytest_cache/
-
-# Native build for tests
-build-native/
-
-# Build directory for tests
-build-test/
 
 # GitHub site publishing
 /work/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "components/esp-idf-lib__i2cdev"]
-	path = components/esp-idf-lib__i2cdev
+[submodule "vendored-components/esp-idf-lib__i2cdev"]
+	path = vendored-components/esp-idf-lib__i2cdev
 	url = https://github.com/cornucopia-machines/i2cdev.git
 	branch = fix/lp-i2c-clock-source

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "components/esp-idf-lib__i2cdev"]
+	path = components/esp-idf-lib__i2cdev
+	url = https://github.com/cornucopia-machines/i2cdev.git
+	branch = fix/lp-i2c-clock-source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,15 +38,21 @@ Before building, activate the ESP-IDF environment:
 . tools/activate_idf.sh spinach   # ESP32-S3 (MK9)
 ```
 
-After sourcing, `idf.py` is on `PATH`. To build and check the result:
+After sourcing, `idf.py` is on `PATH`. Each platform uses a dedicated build
+directory to avoid clobbering the other's compiled artifacts and sdkconfig:
 
 ```sh
-. tools/activate_idf.sh carrot && idf.py build 2>&1 | tail -5
+. tools/activate_idf.sh carrot  && idf.py -B build-carrot  build 2>&1 | tail -5
+. tools/activate_idf.sh spinach && idf.py -B build-spinach build 2>&1 | tail -5
 ```
 
 A successful build ends with `Project build complete.` An error prints the compiler diagnostics before the build aborts. **Do not pipe `idf.py build` through `grep` to check success** — grep's exit code replaces idf.py's, making a clean build look like a failure when grep finds no matches.
 
-The platform argument sets `IDF_TARGET`. When switching platforms, also run `idf.py set-target <target>` to regenerate the sdkconfig — the build will error if it was generated for a different target.
+Pass `-B build-carrot` (or `-B build-spinach`) to every `idf.py` subcommand
+(`flash`, `monitor`, `set-target`, `update-dependencies`, etc.) to keep the two
+build trees isolated. The platform argument sets `IDF_TARGET`; the build will
+error if the sdkconfig in the specified directory was generated for a different
+target.
 
 `tools/activate_idf.sh` reads the IDF version from `main/idf_component.yml`. When upgrading IDF, update the version there (and in `components/kernel/idf_component.yml` and `.github/workflows/build.yml`); the script picks it up automatically.
 

--- a/Common.cmake
+++ b/Common.cmake
@@ -1,4 +1,5 @@
 list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/components")
+list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/vendored-components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 

--- a/components/kernel/idf_component.yml
+++ b/components/kernel/idf_component.yml
@@ -8,11 +8,11 @@ dependencies:
   bblanchon/arduinojson: "7.4.3"
   esp-idf-lib/bh1750: "^1.1.7"
   esp-idf-lib/ds18x20: "^1.2.8"
-  # Pinned via submodule at components/esp-idf-lib__i2cdev (cornucopia-machines fork,
+  # Pinned via submodule at vendored-components/esp-idf-lib__i2cdev (cornucopia-machines fork,
   # branch fix/lp-i2c-clock-source) while the LP_I2C clock-source fix is pending upstream.
   # To revert once esp-idf-lib/i2cdev ships the fix in a new release (>= the version below):
-  #   git submodule deinit components/esp-idf-lib__i2cdev
-  #   git rm components/esp-idf-lib__i2cdev
+  #   git submodule deinit vendored-components/esp-idf-lib__i2cdev
+  #   git rm vendored-components/esp-idf-lib__i2cdev
   #   # Update the version constraint below to the released version that includes the fix
   #   # then run: idf.py -B build-carrot update-dependencies
   # See: https://github.com/esp-idf-lib/i2cdev/issues/12

--- a/components/kernel/idf_component.yml
+++ b/components/kernel/idf_component.yml
@@ -8,6 +8,15 @@ dependencies:
   bblanchon/arduinojson: "7.4.3"
   esp-idf-lib/bh1750: "^1.1.7"
   esp-idf-lib/ds18x20: "^1.2.8"
+  # Pinned via submodule at components/esp-idf-lib__i2cdev (cornucopia-machines fork,
+  # branch fix/lp-i2c-clock-source) while the LP_I2C clock-source fix is pending upstream.
+  # To revert once esp-idf-lib/i2cdev ships the fix in a new release (>= the version below):
+  #   git submodule deinit components/esp-idf-lib__i2cdev
+  #   git rm components/esp-idf-lib__i2cdev
+  #   # Update the version constraint below to the released version that includes the fix
+  #   # then run: idf.py -B build-carrot update-dependencies
+  # See: https://github.com/esp-idf-lib/i2cdev/issues/12
+  #      https://github.com/espressif/idf-component-manager/issues/99
   esp-idf-lib/i2cdev: "^2.1.1"
   esp-idf-lib/ina219: "^1.0.7"
   esp-idf-lib/sht3x: "^1.0.8"

--- a/components/kernel/src/I2CManager.hpp
+++ b/components/kernel/src/I2CManager.hpp
@@ -194,10 +194,10 @@ private:
     Mutex mutex;
     std::vector<std::shared_ptr<I2CBus>> buses;
 
-    // On ESP32-C6: LP_I2C_NUM_0 is pin-locked to GPIO6/GPIO7; the single HP bus is I2C_NUM_0.
+    // On chips with LP_I2C (ESP32-C6): LP_I2C_NUM_0 is pin-locked to GPIO6/GPIO7; the single HP bus is I2C_NUM_0.
     // On other platforms (ESP32-S3): all buses are HP, assigned in registration order.
     i2c_port_t selectPort(const InternalPinPtr& sda, const InternalPinPtr& scl) {
-#if CONFIG_IDF_TARGET_ESP32C6
+#if SOC_LP_I2C_SUPPORTED
         if (sda->getGpio() == GPIO_NUM_6 && scl->getGpio() == GPIO_NUM_7) {
             return LP_I2C_NUM_0;
         }

--- a/components/kernel/src/I2CManager.hpp
+++ b/components/kernel/src/I2CManager.hpp
@@ -187,7 +187,6 @@ public:
             static_cast<int>(port), sda->getName().c_str(), scl->getName().c_str());
         auto bus = std::make_shared<I2CBus>(I2CBus { .port = port, .sda = sda, .scl = scl });
         buses.push_back(bus);
-        preInstallIfLp(*bus);
         return bus;
     }
 
@@ -213,27 +212,6 @@ private:
             throw std::runtime_error("Maximum number of I2C buses reached");
         }
         return static_cast<i2c_port_t>(buses.size());
-#endif
-    }
-
-    // Pre-install LP_I2C with the correct lp_source_clk before any i2cdev consumer can attempt
-    // to install it with the wrong clk_source (which would return ESP_ERR_NOT_SUPPORTED).
-    static void preInstallIfLp([[maybe_unused]] const I2CBus& bus) {
-#if CONFIG_IDF_TARGET_ESP32C6
-        if (bus.port != LP_I2C_NUM_0) {
-            return;
-        }
-        i2c_master_bus_config_t config = {};
-        config.i2c_port = bus.port;
-        config.sda_io_num = bus.sda->getGpio();
-        config.scl_io_num = bus.scl->getGpio();
-        config.lp_source_clk = LP_I2C_SCLK_DEFAULT;
-        config.glitch_ignore_cnt = 7;
-        config.flags.enable_internal_pullup = true;
-        i2c_master_bus_handle_t handle;
-        ESP_ERROR_THROW(i2c_new_master_bus(&config, &handle));
-        LOGTI(I2C, "Pre-installed LP_I2C bus on port %d (SDA: %s, SCL: %s)",
-            static_cast<int>(bus.port), bus.sda->getName().c_str(), bus.scl->getName().c_str());
 #endif
     }
 };

--- a/docs/specs/I2C-buses-for-Carrot.md
+++ b/docs/specs/I2C-buses-for-Carrot.md
@@ -286,17 +286,17 @@ results in RTC slow memory — far more work than the gain.
 
 ### Code changes for MK11+
 
-Two narrow changes in `components/kernel/src/I2CManager.hpp`:
+One change in `components/kernel/src/I2CManager.hpp`, plus an i2cdev fix:
 
-1. **Pin-aware port allocation.** `getBusFor(sda, scl)` currently assigns
-   ports in registration order. On ESP32-C6, allocate `LP_I2C_NUM_0` when
-   the requested pair is `(GPIO_NUM_6, GPIO_NUM_7)`; otherwise pick the
-   next free HP port (just `I2C_NUM_0`, since C6 has only one HP I²C). On
-   ESP32-S3, behavior is unchanged.
+1. **Pin-aware port allocation.** `getBusFor(sda, scl)` allocates
+   `LP_I2C_NUM_0` when the requested pair is `(GPIO_NUM_6, GPIO_NUM_7)` on
+   chips with `SOC_LP_I2C_SUPPORTED`; otherwise picks the next free HP port
+   (`I2C_NUM_0` on ESP32-C6, registration order on ESP32-S3). Implemented.
 
-2. **Per-port clock-source.** When installing the bus, use
-   `lp_source_clk = LP_I2C_SCLK_DEFAULT` for the LP port and
-   `clk_source = I2C_CLK_SRC_DEFAULT` for HP ports.
+2. **Per-port clock-source.** i2cdev handles this: the patched fork detects
+   `LP_I2C_NUM_0` and sets `LP_I2C_SCLK_DEFAULT` instead of
+   `I2C_CLK_SRC_DEFAULT`. No change needed in `I2CManager`. Implemented via
+   the `components/esp-idf-lib__i2cdev` submodule.
 
 ### i2cdev LP_I2C fix
 
@@ -325,13 +325,12 @@ works on LP_I2C without modification.
 
 ### Implementation checklist
 
-- [x] Pin-aware port assignment in `I2CManager::getBusFor` for ESP32-C6
-      (LP_I2C_NUM_0 for `(GPIO_NUM_6, GPIO_NUM_7)`, I2C_NUM_0 otherwise).
-- [x] Per-port clock-source selection (`lp_source_clk` for LP_I2C,
-      `clk_source` for HP) on bus install.
-- [x] Switch i2cdev to fork with LP_I2C fix (`components/esp-idf-lib__i2cdev`
-      submodule); remove `preInstallIfLp` from `I2CManager`. See
-      [Long-term i2cdev strategy](#long-term-i2cdev-strategy).
+- [x] Pin-aware port assignment in `I2CManager::selectPort` — `LP_I2C_NUM_0`
+      for `(GPIO_NUM_6, GPIO_NUM_7)` on `SOC_LP_I2C_SUPPORTED` chips,
+      `I2C_NUM_0` otherwise.
+- [x] Per-port clock-source selection — handled by the patched i2cdev fork
+      (`components/esp-idf-lib__i2cdev` submodule); `preInstallIfLp` removed.
+      See [Long-term i2cdev strategy](#long-term-i2cdev-strategy).
 - [ ] New `UglyDucklingMk11.hpp` device definition (mirrors MK10 with
       GPIO6/7 swapped to the internal bus).
 - [ ] Hardware bring-up on MK11+: BQ27220 and INA219 over LP_I2C0,
@@ -339,12 +338,14 @@ works on LP_I2C without modification.
 
 ## Long-term i2cdev strategy
 
-`preInstallIfLp` and the remaining LP_I2C limitations both stem from the same
-root cause: `esp-idf-lib/i2cdev` hardcodes `.clk_source = I2C_CLK_SRC_DEFAULT`
-in `i2c_new_master_bus`, but for `LP_I2C_NUM_0` the correct value is
-`LP_I2C_SCLK_DEFAULT`. (`clk_source` and `lp_source_clk` are union members in
-`i2c_master_bus_config_t` — both field names work, the value is what matters.)
-This is a bug — any project using i2cdev with `LP_I2C_NUM_0` silently fails.
+The LP_I2C limitation in `esp-idf-lib/i2cdev` stems from a hardcoded
+`.clk_source = I2C_CLK_SRC_DEFAULT` in `i2c_new_master_bus`. For
+`LP_I2C_NUM_0` the correct value is `LP_I2C_SCLK_DEFAULT` (`clk_source` and
+`lp_source_clk` are union members in `i2c_master_bus_config_t` — both field
+names work, the value is what matters). This is a bug — any project using
+i2cdev with `LP_I2C_NUM_0` silently fails. The fix is applied in our fork and
+PR [esp-idf-lib/i2cdev#13](https://github.com/esp-idf-lib/i2cdev/pull/13) is
+open upstream.
 
 ### Fix plan
 

--- a/docs/specs/I2C-buses-for-Carrot.md
+++ b/docs/specs/I2C-buses-for-Carrot.md
@@ -301,9 +301,9 @@ Two narrow changes in `components/kernel/src/I2CManager.hpp`:
 ### i2cdev LP_I2C limitation and workaround
 
 `i2cdev.c` hardcodes `.clk_source = I2C_CLK_SRC_DEFAULT` when calling
-`i2c_new_master_bus`. For `LP_I2C_NUM_0` this is the wrong field — LP_I2C
-requires `.lp_source_clk` — so i2cdev fails with `ESP_ERR_NOT_SUPPORTED` when
-asked to install the LP bus on its own.
+`i2c_new_master_bus`. For `LP_I2C_NUM_0` this is the wrong value — LP_I2C
+requires `LP_I2C_SCLK_DEFAULT` — so i2cdev fails with `ESP_ERR_NOT_SUPPORTED`
+when asked to install the LP bus on its own.
 
 `I2CManager::preInstallIfLp` side-steps this by calling `i2c_new_master_bus`
 directly with `lp_source_clk = LP_I2C_SCLK_DEFAULT` the first time `getBusFor`
@@ -351,20 +351,22 @@ driver (including INA219) works on LP_I2C without modification.
 
 `preInstallIfLp` and the remaining LP_I2C limitations both stem from the same
 root cause: `esp-idf-lib/i2cdev` hardcodes `.clk_source = I2C_CLK_SRC_DEFAULT`
-in `i2c_new_master_bus`, but `LP_I2C_NUM_0` requires `.lp_source_clk` instead.
+in `i2c_new_master_bus`, but for `LP_I2C_NUM_0` the correct value is
+`LP_I2C_SCLK_DEFAULT`. (`clk_source` and `lp_source_clk` are union members in
+`i2c_master_bus_config_t` — both field names work, the value is what matters.)
 This is a bug — any project using i2cdev with `LP_I2C_NUM_0` silently fails.
 
 ### Fix plan
 
 Three issues/PRs against `https://github.com/esp-idf-lib/i2cdev`:
 
-**1. LP_I2C support (bug fix — file as PR)**
+**1. LP_I2C support (bug fix — [esp-idf-lib/i2cdev#12](https://github.com/esp-idf-lib/i2cdev/issues/12))**
 
-In `i2c_setup_port`, detect `LP_I2C_NUM_0` and build the bus config with
-`.lp_source_clk = LP_I2C_SCLK_DEFAULT` instead of
-`.clk_source = I2C_CLK_SRC_DEFAULT`. Guard with `#ifdef LP_I2C_NUM_0` so the
-change is a no-op on chips without LP_I2C. The `clk_flags` field already in
-`i2c_dev_t` is currently dead code and could be wired through here.
+In `i2c_setup_port`, detect `LP_I2C_NUM_0` and use `.clk_source =
+LP_I2C_SCLK_DEFAULT` instead of `.clk_source = I2C_CLK_SRC_DEFAULT`. Guard
+with `#if SOC_LP_I2C_SUPPORTED` so the change is a no-op on chips without
+LP_I2C. The `clk_flags` field already in `i2c_dev_t` is currently dead code
+and could be wired through here.
 
 This is a ~15-line change. Once active in our fork and the dependency updated,
 `preInstallIfLp` is removed from `I2CManager`, and every i2cdev-based driver —

--- a/docs/specs/I2C-buses-for-Carrot.md
+++ b/docs/specs/I2C-buses-for-Carrot.md
@@ -298,34 +298,28 @@ Two narrow changes in `components/kernel/src/I2CManager.hpp`:
    `lp_source_clk = LP_I2C_SCLK_DEFAULT` for the LP port and
    `clk_source = I2C_CLK_SRC_DEFAULT` for HP ports.
 
-### Working around `i2cdev`'s clock-source assumption
+### i2cdev LP_I2C limitation and workaround
 
-`managed_components/esp-idf-lib__i2cdev/i2cdev.c:426` hard-codes
-`clk_source = I2C_CLK_SRC_DEFAULT` on its `i2c_new_master_bus` call. The IDF
-test above proves that returns `ESP_ERR_NOT_SUPPORTED` for LP_I2C, so we
-cannot let `i2cdev` be the first thing to install the LP_I2C bus.
+`i2cdev.c` hardcodes `.clk_source = I2C_CLK_SRC_DEFAULT` when calling
+`i2c_new_master_bus`. For `LP_I2C_NUM_0` this is the wrong field — LP_I2C
+requires `.lp_source_clk` — so i2cdev fails with `ESP_ERR_NOT_SUPPORTED` when
+asked to install the LP bus on its own.
 
-We already use the inverse handle-reuse pattern today in `Bq27220Driver`
-(see the comment at `components/kernel/src/drivers/Bq27220Driver.hpp:81–86`):
-`espressif/i2c_bus` — which BQ27220 sits on — calls
-`i2c_master_get_bus_handle()` first and only calls `i2c_new_master_bus()` if
-no bus exists. For MK11+ we apply the same pattern, just flipped:
+`I2CManager::preInstallIfLp` side-steps this by calling `i2c_new_master_bus`
+directly with `lp_source_clk = LP_I2C_SCLK_DEFAULT` the first time `getBusFor`
+sees `LP_I2C_NUM_0`. This is already implemented and the bus installs correctly.
+`espressif/bq27220`'s data-path operations are unaffected: `espressif/i2c_bus`
+calls `i2c_master_get_bus_handle()` first and reuses the pre-installed handle.
 
-- `I2CManager` installs the LP_I2C bus itself with the correct
-  `lp_source_clk` **before** any `i2cdev`-using driver touches the port.
-- `espressif/bq27220` finds the existing handle via
-  `i2c_master_get_bus_handle()` and reuses it — the BQ27220 path "just
-  works."
+However, i2cdev's internal `port_state->installed` flag is never set by the
+pre-install, so any i2cdev device later targeting the LP port will attempt a
+second `i2c_new_master_bus` and fail with `ESP_ERR_INVALID_STATE`. The drivers
+currently affected are `Bq27220Driver` (via `I2CDevice::probeRead()`) and
+`Ina219Driver` (uses i2cdev directly).
 
-There is one wrinkle: `esp-idf-lib/i2cdev` does _not_ do a handle-reuse
-lookup before its `i2c_new_master_bus` call. If an `i2cdev`-based driver
-later targets the pre-installed LP_I2C port, the second install fails and
-`i2cdev` marks the port unusable. `Ina219Driver` is the only such driver on
-the internal bus today. The narrowest fix is to give `Ina219Driver` the same
-"reuse if present" treatment BQ27220 already gets — either by accepting a
-preinstalled `i2c_master_bus_handle_t` directly, or by routing it through
-our `I2CDevice` abstraction. The decision can wait until MK11+ bring-up;
-it is a one-driver problem, not a tree-wide one.
+The root fix belongs upstream — see [Long-term i2cdev strategy](#long-term-i2cdev-strategy).
+Once i2cdev is LP-aware, `preInstallIfLp` is removed and every i2cdev-based
+driver (including INA219) works on LP_I2C without modification.
 
 ### What does _not_ change
 
@@ -344,13 +338,100 @@ it is a one-driver problem, not a tree-wide one.
       `clk_source` for HP) on bus install.
 - [x] Pre-install the LP_I2C bus in `I2CManager` before any `i2cdev`
       consumer touches the port.
-- [ ] Accommodate `Ina219Driver` so it reuses the existing bus handle
-      instead of going through `i2cdev`'s install path (or accept a
-      preinstalled handle).
+- [ ] Switch i2cdev dependency to the fork with LP-awareness fix; remove
+      `preInstallIfLp` from `I2CManager`. Until this lands, `Bq27220Driver`
+      probeRead and `Ina219Driver` cannot run on LP_I2C. See
+      [Long-term i2cdev strategy](#long-term-i2cdev-strategy).
 - [ ] New `UglyDucklingMk11.hpp` device definition (mirrors MK10 with
       GPIO6/7 swapped to the internal bus).
 - [ ] Hardware bring-up on MK11+: BQ27220 and INA219 over LP_I2C0,
       pluggable peripherals over HP_I2C0.
+
+## Long-term i2cdev strategy
+
+`preInstallIfLp` and the remaining LP_I2C limitations both stem from the same
+root cause: `esp-idf-lib/i2cdev` hardcodes `.clk_source = I2C_CLK_SRC_DEFAULT`
+in `i2c_new_master_bus`, but `LP_I2C_NUM_0` requires `.lp_source_clk` instead.
+This is a bug — any project using i2cdev with `LP_I2C_NUM_0` silently fails.
+
+### Fix plan
+
+Three issues/PRs against `https://github.com/esp-idf-lib/i2cdev`:
+
+**1. LP_I2C support (bug fix — file as PR)**
+
+In `i2c_setup_port`, detect `LP_I2C_NUM_0` and build the bus config with
+`.lp_source_clk = LP_I2C_SCLK_DEFAULT` instead of
+`.clk_source = I2C_CLK_SRC_DEFAULT`. Guard with `#ifdef LP_I2C_NUM_0` so the
+change is a no-op on chips without LP_I2C. The `clk_flags` field already in
+`i2c_dev_t` is currently dead code and could be wired through here.
+
+This is a ~15-line change. Once active in our fork and the dependency updated,
+`preInstallIfLp` is removed from `I2CManager`, and every i2cdev-based driver —
+including `Ina219Driver` — works on LP_I2C without modification.
+
+**2. Externally pre-installed bus handle adoption (enhancement — file as issue)**
+
+i2cdev should call `i2c_master_get_bus_handle` before `i2c_new_master_bus` and
+silently adopt an existing handle rather than failing with
+`ESP_ERR_INVALID_STATE`. This is the same pattern `espressif/i2c_bus` already
+implements. It makes i2cdev robust when other components (e.g. `esp_lcd`) or
+application code pre-installs a bus on the same port.
+
+Not required for our use case once fix 1 lands (since `preInstallIfLp` is
+removed), but useful defensive behaviour for the wider ecosystem. File with a
+sketch of the `externally_owned` flag approach and the `espressif/i2c_bus`
+prior art.
+
+**3. Port pre-registration API (enhancement — file as issue)**
+
+An `i2cdev_open_port(port, sda, scl)` function that installs the bus without
+requiring a dummy device. Useful for ensuring LP_I2C (or any bus) is installed
+at a well-defined point in startup rather than lazily on first transaction. Can
+be filed together with or as a follow-on to issue 2.
+
+### Interim approach
+
+Fork `esp-idf-lib/i2cdev`, apply fix 1, and point the project at the fork via
+a git reference in `idf_component.yml` while the upstream PR is in review. This
+unblocks MK11+ bring-up without waiting for a merge.
+
+### Effect on our codebase once fix 1 is active
+
+- `preInstallIfLp` removed from `I2CManager`.
+- No `I2CDevice` LP bypass needed — i2cdev installs LP_I2C correctly on first use.
+- `Ina219Driver` LP limitation removed — works on LP_I2C like any other i2cdev driver.
+- `i2cdev_init` / `i2cdev_done` calls in `I2CManager` unchanged.
+
+### Option B: Migrate off i2cdev entirely
+
+If the PR does not land in time for MK11+ bring-up, or if the esp-idf-lib
+organisation declines the change, the alternative is to replace each
+i2cdev-based driver with an implementation that uses the new `i2c_master`
+API directly (through `I2CDevice`).
+
+| Chip | Current dep | Replacement path |
+| ---- | ----------- | ---------------- |
+| SHT3x | `esp-idf-lib/sht3x` | `espressif/sht3x` v0.2.0 — Espressif-official, wraps `espressif/i2c_bus` which does handle-reuse exactly like bq27220. Dependency swap only, no code changes. |
+| SI7021 / SHT2x | `esp-idf-lib/si7021` | Port required. No maintained `i2c_master` alternative exists. The protocol is simple (~50 lines of I2C transactions). |
+| BH1750 | `esp-idf-lib/bh1750` | `k0i05/esp_bh1750` v1.2.7 on the component registry — raw `i2c_master` API, actively maintained, MIT. |
+| TSL2591 | `esp-idf-lib/tsl2591` | Port required from the existing MIT-licensed source (~200 lines of register-map I2C code). No new-API alternative found. |
+| INA219 | `esp-idf-lib/ina219` | Port required. `fborello-lambda/solar_panel_curve_tracer` on GitHub is a clean, complete reference using the new API. |
+
+The two drop-in swaps (SHT3x, BH1750) require no I2C-level changes; the three
+ports (SI7021, TSL2591, INA219) require implementing protocol logic against
+`I2CDevice`. End state: no i2cdev dependency, `I2CDevice` uses the new
+`i2c_master` API directly, no `#if` guards.
+
+### Which to pursue
+
+Apply fix 1 to the fork first — the code change is small, clearly a bug, and
+unblocks MK11+ bring-up regardless of upstream merge timeline. File issue 2
+(handle-adoption) separately so the upstream maintainers can evaluate it
+independently of the bug fix. If fix 1 merges upstream, Option B reduces to the
+three ports with no ready-made drop-in (SI7021, TSL2591, INA219), which can be
+ported lazily. If upstream is unresponsive, stay on the fork until a decision
+is made on Option B.
 
 ## Out of scope
 

--- a/docs/specs/I2C-buses-for-Carrot.md
+++ b/docs/specs/I2C-buses-for-Carrot.md
@@ -298,28 +298,21 @@ Two narrow changes in `components/kernel/src/I2CManager.hpp`:
    `lp_source_clk = LP_I2C_SCLK_DEFAULT` for the LP port and
    `clk_source = I2C_CLK_SRC_DEFAULT` for HP ports.
 
-### i2cdev LP_I2C limitation and workaround
+### i2cdev LP_I2C fix
 
-`i2cdev.c` hardcodes `.clk_source = I2C_CLK_SRC_DEFAULT` when calling
+`i2cdev.c` hardcoded `.clk_source = I2C_CLK_SRC_DEFAULT` when calling
 `i2c_new_master_bus`. For `LP_I2C_NUM_0` this is the wrong value — LP_I2C
-requires `LP_I2C_SCLK_DEFAULT` — so i2cdev fails with `ESP_ERR_NOT_SUPPORTED`
-when asked to install the LP bus on its own.
+requires `LP_I2C_SCLK_DEFAULT` — so i2cdev failed with `ESP_ERR_NOT_SUPPORTED`
+when asked to install the LP bus.
 
-`I2CManager::preInstallIfLp` side-steps this by calling `i2c_new_master_bus`
-directly with `lp_source_clk = LP_I2C_SCLK_DEFAULT` the first time `getBusFor`
-sees `LP_I2C_NUM_0`. This is already implemented and the bus installs correctly.
-`espressif/bq27220`'s data-path operations are unaffected: `espressif/i2c_bus`
-calls `i2c_master_get_bus_handle()` first and reuses the pre-installed handle.
-
-However, i2cdev's internal `port_state->installed` flag is never set by the
-pre-install, so any i2cdev device later targeting the LP port will attempt a
-second `i2c_new_master_bus` and fail with `ESP_ERR_INVALID_STATE`. The drivers
-currently affected are `Bq27220Driver` (via `I2CDevice::probeRead()`) and
-`Ina219Driver` (uses i2cdev directly).
-
-The root fix belongs upstream — see [Long-term i2cdev strategy](#long-term-i2cdev-strategy).
-Once i2cdev is LP-aware, `preInstallIfLp` is removed and every i2cdev-based
-driver (including INA219) works on LP_I2C without modification.
+This is fixed in our fork (`cornucopia-machines/i2cdev`,
+branch `fix/lp-i2c-clock-source`, upstream issue
+[esp-idf-lib/i2cdev#12](https://github.com/esp-idf-lib/i2cdev/issues/12)).
+The fork is pinned as a git submodule at `components/esp-idf-lib__i2cdev/`,
+which shadows the registry version for all consumers. With the fix in place,
+i2cdev installs LP_I2C correctly on first use — `preInstallIfLp` has been
+removed from `I2CManager`, and every i2cdev-based driver (including INA219)
+works on LP_I2C without modification.
 
 ### What does _not_ change
 
@@ -336,11 +329,8 @@ driver (including INA219) works on LP_I2C without modification.
       (LP_I2C_NUM_0 for `(GPIO_NUM_6, GPIO_NUM_7)`, I2C_NUM_0 otherwise).
 - [x] Per-port clock-source selection (`lp_source_clk` for LP_I2C,
       `clk_source` for HP) on bus install.
-- [x] Pre-install the LP_I2C bus in `I2CManager` before any `i2cdev`
-      consumer touches the port.
-- [ ] Switch i2cdev dependency to the fork with LP-awareness fix; remove
-      `preInstallIfLp` from `I2CManager`. Until this lands, `Bq27220Driver`
-      probeRead and `Ina219Driver` cannot run on LP_I2C. See
+- [x] Switch i2cdev to fork with LP_I2C fix (`components/esp-idf-lib__i2cdev`
+      submodule); remove `preInstallIfLp` from `I2CManager`. See
       [Long-term i2cdev strategy](#long-term-i2cdev-strategy).
 - [ ] New `UglyDucklingMk11.hpp` device definition (mirrors MK10 with
       GPIO6/7 swapped to the internal bus).
@@ -392,18 +382,19 @@ requiring a dummy device. Useful for ensuring LP_I2C (or any bus) is installed
 at a well-defined point in startup rather than lazily on first transaction. Can
 be filed together with or as a follow-on to issue 2.
 
-### Interim approach
+### Current state
 
-Fork `esp-idf-lib/i2cdev`, apply fix 1, and point the project at the fork via
-a git reference in `idf_component.yml` while the upstream PR is in review. This
-unblocks MK11+ bring-up without waiting for a merge.
+Fix 1 is applied in our fork and the project uses it via the
+`components/esp-idf-lib__i2cdev` submodule (see `components/kernel/idf_component.yml`
+for rollback instructions). The ESP-IDF component manager cannot override a
+transitive registry dependency with a git source when both satisfy the semver
+constraint ([idf-component-manager#99](https://github.com/espressif/idf-component-manager/issues/99)),
+so a submodule in `components/` is the supported workaround until the upstream
+issue is resolved.
 
-### Effect on our codebase once fix 1 is active
-
-- `preInstallIfLp` removed from `I2CManager`.
-- No `I2CDevice` LP bypass needed — i2cdev installs LP_I2C correctly on first use.
-- `Ina219Driver` LP limitation removed — works on LP_I2C like any other i2cdev driver.
-- `i2cdev_init` / `i2cdev_done` calls in `I2CManager` unchanged.
+Once `esp-idf-lib/i2cdev` releases a version with the fix:
+- Remove the submodule (`git submodule deinit components/esp-idf-lib__i2cdev && git rm components/esp-idf-lib__i2cdev`)
+- Update the semver pin in `components/kernel/idf_component.yml` to the released version
 
 ### Option B: Migrate off i2cdev entirely
 

--- a/tools/activate_idf.sh
+++ b/tools/activate_idf.sh
@@ -11,7 +11,7 @@
 # When upgrading IDF, update the version in main/idf_component.yml (and
 # components/kernel/idf_component.yml and .github/workflows/build.yml);
 # this script will pick it up automatically.
-VERSION=$(grep 'version:' main/idf_component.yml | tr -d ' "' | cut -d: -f2)
+VERSION=$(grep -m 1 'version:' main/idf_component.yml | tr -d ' "' | cut -d: -f2)
 . "$HOME/.espressif/tools/activate_idf_v${VERSION}.sh"
 
 case "$1" in


### PR DESCRIPTION
## Summary

Prepares LP_I2C support for MK11+, which will route the internal bus
(BQ27220, INA219) to GPIO6/GPIO7 — the pins LP_I2C_NUM_0 is hardware-locked
to on ESP32-C6 — freeing HP_I2C0 for the external peripheral bus.

- **i2cdev LP_I2C fix**: `esp-idf-lib/i2cdev` hardcoded `I2C_CLK_SRC_DEFAULT`
  when installing a bus; for `LP_I2C_NUM_0` the correct value is
  `LP_I2C_SCLK_DEFAULT`, causing `ESP_ERR_NOT_SUPPORTED`. Fixed in our fork
  ([esp-idf-lib/i2cdev#13](https://github.com/esp-idf-lib/i2cdev/pull/13));
  pinned as a git submodule at `vendored-components/esp-idf-lib__i2cdev/` while the
  upstream PR is in review (workaround for
  [idf-component-manager#99](https://github.com/espressif/idf-component-manager/issues/99)).
- **Remove `preInstallIfLp`**: the workaround that pre-installed the LP bus
  from `I2CManager` before i2cdev could touch it is no longer needed and has
  been removed.
- **`SOC_LP_I2C_SUPPORTED` guard**: `selectPort` now uses the capability macro
  instead of `CONFIG_IDF_TARGET_ESP32C6`, so it extends naturally to any future
  chip with LP_I2C hardware.

## What was tested

- Carrot (ESP32-C6) build passes cleanly with the patched i2cdev submodule.
- Spinach (ESP32-S3) build is unaffected — `SOC_LP_I2C_SUPPORTED` is false
  there and all LP_I2C paths are compiled out.

## Platform / target

- Carrot: `IDF_TARGET=esp32c6` ✅
- Spinach: `IDF_TARGET=esp32s3` ✅ (unaffected)

## Related

- Spec: `docs/specs/I2C-buses-for-Carrot.md`
- Upstream i2cdev bug: [esp-idf-lib/i2cdev#12](https://github.com/esp-idf-lib/i2cdev/issues/12)
- Upstream i2cdev fix PR: [esp-idf-lib/i2cdev#13](https://github.com/esp-idf-lib/i2cdev/pull/13)
- Handle-adoption enhancement: [esp-idf-lib/i2cdev#14](https://github.com/esp-idf-lib/i2cdev/issues/14)
- Component manager override limitation: [idf-component-manager#99](https://github.com/espressif/idf-component-manager/issues/99)

## NVS config changes

None.