### PR TITLE
Log battery voltage, percentage, and temperature at boot

### DIFF
--- a/components/kernel/src/drivers/Bq27220Driver.hpp
+++ b/components/kernel/src/drivers/Bq27220Driver.hpp
@@ -105,6 +105,8 @@ public:
             .cedv = &default_cedv,
         };
         gauge = bq27220_create(&bq27220_cfg);
+
+        LOGI("Battery voltage at boot: %d mV / %.2f%%; temp = %.2f°C", getVoltage(), getPercentage(), getTemperature());
     }
 
     int getVoltage() override {


### PR DESCRIPTION
## Summary
- Adds a single `LOGI` call at the end of `Bq27220Driver` construction to log voltage (mV), percentage (%), and temperature (°C) at boot

## Test plan
- [ ] Build for `spinach` (ESP32-S3, MK9) — verify no compile errors
- [ ] Serial monitor on a device with BQ27220 — confirm boot log line appears

**Platform:** spinach / carrot (both use `Bq27220Driver`)
**NVS config changes:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fH7yhbvWhqFJ3DLs5LPac