### PR TITLE
Upgrade ESP-IDF to v6.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ env:
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   CCACHE_MAXSIZE: 256M
   CCACHE_COMPRESS: true
-  ESP_IDF_VERSION: v6.0.1
+  ESP_IDF_VERSION: v6.0.2
   TEST_TARGET: esp32s3
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The following commands are available to manage NVS entries on the device:
 
 ### Prerequisites
 
-- [ESP-IDF-Clang Docker image](https://github.com/lptr/esp-idf-clang-docker) (wraps ESP-IDF v6.0.1 with Clang toolchain)
+- [ESP-IDF-Clang Docker image](https://github.com/lptr/esp-idf-clang-docker) (wraps ESP-IDF v6.0.2 with Clang toolchain)
 
 ### Building
 

--- a/components/kernel/idf_component.yml
+++ b/components/kernel/idf_component.yml
@@ -1,10 +1,10 @@
 ## IDF Component Manager Manifest File
 dependencies:
   idf:
-    version: "6.0.1"
+    version: "6.0.2"
   espressif/mqtt: "^1.0.0"
-  espressif/network_provisioning: "^1.2.2"
-  espressif/bq27220: "^0.1.0"
+  espressif/network_provisioning: "^1.2.4"
+  espressif/bq27220: "^0.1.1"
   bblanchon/arduinojson: "7.4.3"
   esp-idf-lib/bh1750: "^1.1.7"
   esp-idf-lib/ds18x20: "^1.2.8"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,4 +1,4 @@
 ## IDF Component Manager Manifest File
 dependencies:
   idf:
-    version: "6.0.1"
+    version: "6.0.2"


### PR DESCRIPTION
## Summary
- Bumps ESP-IDF from v6.0.1 → v6.0.2 in `main/idf_component.yml`, `components/kernel/idf_component.yml`, and CI workflow
- Updates README reference to the Docker image
- Bumps `espressif/network_provisioning` to `^1.2.4` and `espressif/bq27220` to `^0.1.1`

## Test plan
- [ ] CI build passes for both `spinach` (ESP32-S3) and `carrot` (ESP32-C6) targets
- [ ] `idf.py update-dependencies` run locally to verify `dependencies.lock` resolves cleanly

**Platform:** spinach + carrot
**NVS config changes:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fH7yhbvWhqFJ3DLs5LPac