### PR TITLE
Fix ESP32-C6 BLE/WiFi power draw; disable BLE on Spinach

### DIFF
--- a/DeviceCommon.cmake
+++ b/DeviceCommon.cmake
@@ -90,6 +90,20 @@ if(UD_DEBUG)
     add_compile_definitions(DUMP_MQTT)
 endif()
 
+# UD_PM_DIAGNOSTICS — separate from UD_DEBUG since debug builds already disable light sleep
+# entirely (see PowerManager::shouldSleepWhenIdle), which would make PM diagnostics useless.
+
+if(NOT DEFINED UD_PM_DIAGNOSTICS)
+    set(UD_PM_DIAGNOSTICS "$ENV{UD_PM_DIAGNOSTICS}")
+endif()
+if(UD_PM_DIAGNOSTICS STREQUAL "")
+    set(UD_PM_DIAGNOSTICS 0)
+endif()
+
+if(UD_PM_DIAGNOSTICS)
+    add_compile_definitions(UD_PM_DIAGNOSTICS)
+endif()
+
 # WOKWI
 
 if(NOT DEFINED WOKWI)
@@ -110,12 +124,17 @@ if(WOKWI)
     endif()
 endif()
 
-# Make sure we reconfigure if UD_DEBUG changes
-set_property(DIRECTORY PROPERTY UD_DEBUG_TRACKER "${UD_DEBUG}")
+# Make sure we reconfigure if UD_DEBUG or UD_PM_DIAGNOSTICS changes
+set_property(DIRECTORY PROPERTY UD_DEBUG_TRACKER "${UD_DEBUG} ${UD_PM_DIAGNOSTICS}")
 
 set(SDKCONFIG_FILES)
 list(APPEND SDKCONFIG_FILES "${CMAKE_CURRENT_LIST_DIR}/sdkconfig.defaults")
 list(APPEND SDKCONFIG_FILES "${CMAKE_CURRENT_LIST_DIR}/sdkconfig.${_ud_platform}.defaults")
+
+if (UD_PM_DIAGNOSTICS)
+    message("Building with PM diagnostics")
+    list(APPEND SDKCONFIG_FILES "${CMAKE_CURRENT_LIST_DIR}/sdkconfig.pm_diagnostics.defaults")
+endif()
 
 # Check if UD_DEBUG is defined
 if (UD_DEBUG)

--- a/README.md
+++ b/README.md
@@ -198,6 +198,17 @@ You can add `-DUD_DEBUG=1` to enable debug output:
 idf.py build -DUD_DEBUG=1
 ```
 
+You can add `-DUD_PM_DIAGNOSTICS=1` to enable power-management diagnostics — a periodic
+(every 2.5s) dump of PM lock hold times, `esp_timer` stats, light-sleep wakeup count/causes,
+and per-task CPU time to the console. Real overhead (~9% CPU in testing), not for production
+builds. Separate from `UD_DEBUG` since debug builds disable light sleep entirely, which would
+make PM diagnostics pointless. See `components/kernel/src/PowerManager.hpp` and
+`sdkconfig.pm_diagnostics.defaults`:
+
+```bash
+idf.py build -DUD_PM_DIAGNOSTICS=1
+```
+
 #### Pinning to a specific model (development / simulation)
 
 Pass `UD_GEN` to skip MAC detection and force a specific model.

--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -422,7 +422,8 @@ static void startDevice() {
             "Ugly Duckling " + modelWithRevision,
             firmwareVersion,
             macAddress,
-            bleNvs);
+            bleNvs,
+            settings->bleAdvInterval.get());
     } else {
         LOGI("BLE disabled, using no-op driver");
         ble = std::make_shared<BleDriver>();

--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -412,8 +412,11 @@ static void startDevice() {
     auto states = std::make_shared<ModuleStates>();
     KernelStatusTask::init(statusLed, states);
 
-    // Init BLE (optional — disabled via settings->bleEnabled)
+    // Init BLE (optional — disabled via settings->bleEnabled; compiled out entirely on
+    // platforms without CONFIG_BT_NIMBLE_ENABLED, e.g. Spinach — see docs/specs/Bluetooth.md
+    // "Platform support decision")
     std::shared_ptr<BleDriver> ble;
+#ifdef CONFIG_BT_NIMBLE_ENABLED
     if (settings->bleEnabled.get()) {
         LOGI("BLE enabled, starting NimBLE stack");
         auto bleNvs = std::make_shared<NvsStore>("ble");
@@ -428,6 +431,9 @@ static void startDevice() {
         LOGI("BLE disabled, using no-op driver");
         ble = std::make_shared<BleDriver>();
     }
+#else
+    ble = std::make_shared<BleDriver>();
+#endif
 
     // Init WiFi
     auto wifi = std::make_shared<WiFiDriver>(

--- a/components/devices/src/devices/DeviceSettings.hpp
+++ b/components/devices/src/devices/DeviceSettings.hpp
@@ -15,6 +15,13 @@ struct DeviceSettings : ConfigurationSection {
     Property<bool> bleEnabled { this, "bleEnabled", true };
 
     /**
+     * @brief Gap between BLE advertising bursts. See BleDriver::startAdvertising() —
+     * shorter values increase discoverability/reconnect speed at the cost of power
+     * (each burst re-engages the WiFi/BLE coexistence scheduler briefly).
+     */
+    Property<milliseconds> bleAdvInterval { this, "bleAdvInterval", 2000ms };
+
+    /**
      * @brief How often to publish telemetry.
      */
     Property<seconds> publishInterval { this, "publishInterval", 5min };

--- a/components/devices/src/devices/DeviceSettings.hpp
+++ b/components/devices/src/devices/DeviceSettings.hpp
@@ -12,12 +12,20 @@ struct DeviceSettings : ConfigurationSection {
     ArrayProperty<JsonAsString> functions { this, "functions" };
 
     Property<bool> sleepWhenIdle { this, "sleepWhenIdle", true };
+
+    /**
+     * @brief Runtime BLE on/off switch. Only takes effect on platforms compiled with
+     * CONFIG_BT_NIMBLE_ENABLED (Carrot/MK10+) — see docs/specs/Bluetooth.md "Platform
+     * support decision". On platforms without it (Spinach), BLE is compiled out
+     * entirely and this setting has no effect.
+     */
     Property<bool> bleEnabled { this, "bleEnabled", true };
 
     /**
      * @brief Gap between BLE advertising bursts. See BleDriver::startAdvertising() —
      * shorter values increase discoverability/reconnect speed at the cost of power
-     * (each burst re-engages the WiFi/BLE coexistence scheduler briefly).
+     * (each burst re-engages the WiFi/BLE coexistence scheduler briefly). Only relevant
+     * where BLE is compiled in — see bleEnabled above.
      */
     Property<milliseconds> bleAdvInterval { this, "bleAdvInterval", 2000ms };
 

--- a/components/devices/src/devices/DeviceSettings.hpp
+++ b/components/devices/src/devices/DeviceSettings.hpp
@@ -12,7 +12,7 @@ struct DeviceSettings : ConfigurationSection {
     ArrayProperty<JsonAsString> functions { this, "functions" };
 
     Property<bool> sleepWhenIdle { this, "sleepWhenIdle", true };
-    Property<bool> bleEnabled { this, "bleEnabled", false };
+    Property<bool> bleEnabled { this, "bleEnabled", true };
 
     /**
      * @brief How often to publish telemetry.

--- a/components/kernel/src/PowerManager.hpp
+++ b/components/kernel/src/PowerManager.hpp
@@ -1,12 +1,16 @@
 #pragma once
 
+#include <array>
 #include <chrono>
 
 #include <esp_pm.h>
+#include <esp_sleep.h>
+#include <esp_timer.h>
 
 #include <Concurrent.hpp>
 #include <EspException.hpp>
 #include <Log.hpp>
+#include <Task.hpp>
 #include <Telemetry.hpp>
 
 #if defined(CONFIG_IDF_TARGET_ESP32S2)
@@ -88,6 +92,16 @@ public:
                 auto* self = static_cast<PowerManager*>(arg);
                 self->lightSleepTime += microseconds(timeSleptInUs);
                 self->lightSleepCount++;
+#ifdef UD_PM_DIAGNOSTICS
+                // Tally exact wakeup cause(s) per cycle. Bitmask, so a wake can be
+                // attributed to more than one cause at once.
+                uint32_t causes = esp_sleep_get_wakeup_causes();
+                for (size_t i = 0; i < self->wakeupCauseCounts.size(); i++) {
+                    if (causes & (1u << i)) {
+                        self->wakeupCauseCounts[i]++;
+                    }
+                }
+#endif
                 return ESP_OK;
             },
             .enter_cb_user_arg = nullptr,
@@ -98,16 +112,43 @@ public:
         ESP_ERROR_THROW(esp_pm_light_sleep_register_cbs(&cbs_conf));
 #endif
 
-        //         Task::loop("power-manager", 4096, [this](Task& task) {
-        //             esp_pm_dump_locks(stdout);
-        // #ifdef CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
-        //             static char buffer[2048];
-        //             vTaskGetRunTimeStats(buffer);
-        //             printf("Task Name\tState\tPrio\tStack\tNum\n");
-        //             printf("%s\n", buffer);
-        // #endif
-        //             Task::delay(10s);
-        //         });
+#ifdef UD_PM_DIAGNOSTICS
+        // Dumps PM locks, esp_timer stats, light-sleep wakeup count/causes, and (if
+        // CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS) per-task CPU time every 2.5s. Real
+        // overhead (~9% CPU in testing) — only active in UD_PM_DIAGNOSTICS builds.
+        Task::loop("power-manager", 4096, [this](Task& task) {
+            esp_pm_dump_locks(stdout);
+            esp_timer_dump(stdout);
+#ifdef CONFIG_PM_LIGHT_SLEEP_CALLBACKS
+            printf("Light sleep: %d wakeups, %lld us slept (since last dump)\n",
+                lightSleepCount, static_cast<long long>(lightSleepTime.count()));
+            lightSleepCount = 0;
+            lightSleepTime = microseconds::zero();
+            printf("Wakeup causes (since last dump): TIMER=%lu WIFI=%lu BT=%lu UART=%lu GPIO=%lu OTHER_BITS=",
+                wakeupCauseCounts[ESP_SLEEP_WAKEUP_TIMER],
+                wakeupCauseCounts[ESP_SLEEP_WAKEUP_WIFI],
+                wakeupCauseCounts[ESP_SLEEP_WAKEUP_BT],
+                wakeupCauseCounts[ESP_SLEEP_WAKEUP_UART],
+                wakeupCauseCounts[ESP_SLEEP_WAKEUP_GPIO]);
+            for (size_t i = 0; i < wakeupCauseCounts.size(); i++) {
+                if (wakeupCauseCounts[i] != 0
+                    && i != ESP_SLEEP_WAKEUP_TIMER && i != ESP_SLEEP_WAKEUP_WIFI
+                    && i != ESP_SLEEP_WAKEUP_BT && i != ESP_SLEEP_WAKEUP_UART && i != ESP_SLEEP_WAKEUP_GPIO) {
+                    printf("[bit%u]=%lu ", static_cast<unsigned>(i), wakeupCauseCounts[i]);
+                }
+            }
+            printf("\n");
+            wakeupCauseCounts.fill(0);
+#endif
+#ifdef CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+            static char buffer[2048];
+            vTaskGetRunTimeStats(buffer);
+            printf("Task Name\tState\tPrio\tStack\tNum\n");
+            printf("%s\n", buffer);
+#endif
+            Task::delay(2500ms);
+        });
+#endif
     }
     const bool sleepWhenIdle;
 
@@ -155,6 +196,10 @@ private:
     steady_clock::time_point sleepTimeLastReported = steady_clock::now();
     microseconds lightSleepTime = microseconds::zero();
     int lightSleepCount = 0;
+#ifdef UD_PM_DIAGNOSTICS
+    // Per-wakeup-cause tally, indexed by esp_sleep_wakeup_cause_t bit position
+    std::array<unsigned long, 32> wakeupCauseCounts = { };
+#endif
 #endif
 };
 

--- a/components/kernel/src/PulseCounter.cpp
+++ b/components/kernel/src/PulseCounter.cpp
@@ -230,6 +230,7 @@ std::shared_ptr<PulseCounter> PulseCounterManager::createGpio(const PulseCounter
     if (!gpioInitialized) {
         gpioInitialized = true;
 
+#ifdef CONFIG_PM_LIGHT_SLEEP_CALLBACKS
         // Make sure we handle any state changes when the device wakes up due to a GPIO interrupt
         esp_pm_sleep_cbs_register_config_t sleepCallbackConfig = {
             .enter_cb = [](int64_t /*timeToSleepInUs*/, void* arg) {
@@ -250,6 +251,7 @@ std::shared_ptr<PulseCounter> PulseCounterManager::createGpio(const PulseCounter
             .exit_cb_prior = 0,
         };
         ESP_ERROR_THROW(esp_pm_light_sleep_register_cbs(&sleepCallbackConfig));
+#endif
     }
 
     auto counter = std::make_shared<GpioPulseCounter>(config.pin, config.debounceTime);

--- a/components/kernel/src/drivers/BleDriver.hpp
+++ b/components/kernel/src/drivers/BleDriver.hpp
@@ -9,7 +9,6 @@
 #include <time.h>
 
 #include <esp_random.h>
-#include <esp_timer.h>
 #include <host/ble_gatt.h>
 #include <host/ble_hs.h>    // NOLINT(misc-header-include-cycle) -- ble_hs.h and ble_gap.h include each other; cycle is in ESP-IDF, not our code
 #include <host/ble_hs_mbuf.h>
@@ -112,16 +111,14 @@ public:
         throwOnBleError(ble_svc_dis_firmware_revision_set(this->firmwareVersion.c_str()), "ble_svc_dis_firmware_revision_set");
         throwOnBleError(ble_svc_dis_serial_number_set(this->serialNumber.c_str()), "ble_svc_dis_serial_number_set");
 
-        // Burst-mode advertising timer — see startAdvertising() and the BLE_GAP_EVENT_ADV_COMPLETE
-        // case in gapEventCallback() for why this exists.
-        esp_timer_create_args_t timerArgs = {
-            .callback = advRestartTimerCallback,
-            .arg = this,
-            .dispatch_method = ESP_TIMER_TASK,
-            .name = "ble-adv-restart",
-            .skip_unhandled_events = true,
-        };
-        ESP_ERROR_THROW(esp_timer_create(&timerArgs, &advRestartTimer));
+        // Burst-mode advertising restart — see startAdvertising() and the BLE_GAP_EVENT_ADV_COMPLETE
+        // case in gapEventCallback() for why this exists. A ble_npl_callout (rather than an
+        // esp_timer) runs its callback directly on the NimBLE host's own event queue, so the
+        // restart needs no cross-task marshaling (contrast setWifiStatus/setScanResults, which
+        // use postToHostTask because they're invoked from other drivers' tasks).
+        throwOnBleError(
+            ble_npl_callout_init(&advRestartCallout, nimble_port_get_dflt_eventq(), advRestartCalloutCb, this),
+            "ble_npl_callout_init");
 
         nimble_port_freertos_init(hostTask);
 
@@ -288,12 +285,10 @@ private:
     }
 
     // Fires advBurstInterval after each advertising burst completes (see
-    // BLE_GAP_EVENT_ADV_COMPLETE). Runs on the esp_timer task, not the NimBLE host task, so
-    // marshal the actual restart through postToHostTask like every other cross-task entry point.
-    static void advRestartTimerCallback(void* arg) {
-        postToHostTask([driver = static_cast<NimBleDriver*>(arg)]() {
-            driver->startAdvertising();
-        });
+    // BLE_GAP_EVENT_ADV_COMPLETE). Already runs on the NimBLE host task, since advRestartCallout
+    // was initialized against nimble_port_get_dflt_eventq() — no postToHostTask marshaling needed.
+    static void advRestartCalloutCb(struct ble_npl_event* ev) {
+        static_cast<NimBleDriver*>(ble_npl_event_get_arg(ev))->startAdvertising();
     }
 
     void handleSync() {
@@ -328,11 +323,12 @@ private:
             case BLE_GAP_EVENT_ADV_COMPLETE: {
                 // The single burst event (max_events=1 in startAdvertising) just finished.
                 // Re-arm after advBurstInterval instead of restarting immediately — see
-                // startAdvertising() for why.
-                esp_timer_stop(driver->advRestartTimer);    // harmless if not currently armed
-                int rc = esp_timer_start_once(driver->advRestartTimer, duration_cast<microseconds>(advBurstInterval).count());
-                if (rc != ESP_OK) {
-                    LOGTE(BLE, "Failed to arm advertising restart timer: 0x%02x", rc);
+                // startAdvertising() for why. ble_npl_callout_reset both (re)arms the callout
+                // and is safe to call while already pending, so no separate stop-first step.
+                ble_npl_error_t err = ble_npl_callout_reset(
+                    &driver->advRestartCallout, ble_npl_time_ms_to_ticks32(duration_cast<milliseconds>(advBurstInterval).count()));
+                if (err != BLE_NPL_OK) {
+                    LOGTE(BLE, "Failed to arm advertising restart callout: 0x%02x", err);
                 }
                 break;
             }
@@ -466,7 +462,7 @@ private:
     // in one ble_hs_adv_fields / ble_gap_ext_adv_set_data call.
     //
     // Burst mode: fires a single advertising event (max_events=1 below) instead of advertising
-    // continuously, then re-arms via advRestartTimer after advBurstInterval (see
+    // continuously, then re-arms advRestartCallout after advBurstInterval (see
     // BLE_GAP_EVENT_ADV_COMPLETE in gapEventCallback). Net over-the-air behavior is the same
     // as continuous 2s-interval advertising — one event every ~2s, still connectable — but the
     // WiFi/BLE coexistence scheduler on ESP32-C6 selects its scheme based on the BLE controller's
@@ -474,10 +470,59 @@ private:
     // between 2s-spaced events), coex wakes the chip from light sleep every ~2.8ms to service RF
     // time slices. Idle-between-bursts avoids that entirely. Measured: ~13 mA continuous vs
     // ~3 mA bursty with WiFi station + BLE both active.
+    //
+    // configureAndSetData() below (params + advertising data) runs once, guarded by advConfigured
+    // — every burst after the first calls ONLY ble_gap_ext_adv_start(). Neither the params nor the
+    // AD payload (name/UUIDs) ever change between bursts, and both ble_gap_ext_adv_configure() and
+    // ble_gap_ext_adv_set_data() are real HCI round-trips to the controller, not local struct
+    // updates — repeating them every ~2s was pure waste and, worse, piled extra HCI command/event
+    // traffic onto an already-busy path. Doing that on every burst caused a NimBLE host crash
+    // (npl_freertos_event_init / ble_hs_event_rx_hci_ev, apparent NPL/HCI event pool exhaustion
+    // under sustained WiFi+MQTT+TLS load) a few cycles after boot; configuring once removes the
+    // redundant HCI exchanges regardless of whether that's the full story.
     void startAdvertising() {
         constexpr uint8_t instance = 0;
         if (ble_gap_ext_adv_active(instance) != 0) {
             return;
+        }
+
+        if (!advConfigured && !configureAndSetData(instance)) {
+            return;
+        }
+
+        int rc = ble_gap_ext_adv_start(instance, 0, 1);    // max_events=1: stop after this one burst
+        if (rc != 0 && rc != BLE_HS_EALREADY) {
+            LOGTE(BLE, "Failed to start advertising: 0x%02x", rc);
+            status = BleStatus::Error;
+            return;
+        }
+        status = BleStatus::Advertising;
+        LOGTD(BLE, "Advertising as '%s'", ble_svc_gap_device_name());
+    }
+
+    // One-time setup for startAdvertising(): advertising params + AD payload (flags, name, all
+    // service UUIDs — a single extended AD payload has room for up to 1650 bytes, so unlike the
+    // old legacy-advertising implementation there's no need to split fields between a primary ad
+    // and a separate scan response). Returns false (and sets status = Error) on failure.
+    bool configureAndSetData(uint8_t instance) {
+        struct ble_gap_ext_adv_params params = { };
+        params.connectable = 1;    // must accept CONNECT_IND for phone-based WiFi provisioning
+        params.own_addr_type = BLE_OWN_ADDR_RANDOM;
+        params.primary_phy = BLE_HCI_LE_PHY_1M;
+        params.secondary_phy = BLE_HCI_LE_PHY_1M;
+        params.tx_power = 127;    // let the stack pick
+        params.sid = 0;
+        // Standard "fast advertising interval 1" (30-60ms) so each burst's single event
+        // (max_events=1 in startAdvertising) fires promptly; the ~2s spacing between bursts
+        // comes from advRestartCallout instead.
+        params.itvl_min = BLE_GAP_ADV_FAST_INTERVAL1_MIN;
+        params.itvl_max = BLE_GAP_ADV_FAST_INTERVAL1_MAX;
+
+        int rc = ble_gap_ext_adv_configure(instance, &params, nullptr, gapEventCallback, this);
+        if (rc != 0) {
+            LOGTE(BLE, "Failed to configure extended advertising: 0x%02x", rc);
+            status = BleStatus::Error;
+            return false;
         }
 
         static const std::array<ble_uuid16_t, 3> serviceUuids16 = { {
@@ -499,53 +544,27 @@ private:
         adFields.num_uuids128 = 1;
         adFields.uuids128_is_complete = 1;
 
-        struct ble_gap_ext_adv_params params = { };
-        params.connectable = 1;    // must accept CONNECT_IND for phone-based WiFi provisioning
-        params.own_addr_type = BLE_OWN_ADDR_RANDOM;
-        params.primary_phy = BLE_HCI_LE_PHY_1M;
-        params.secondary_phy = BLE_HCI_LE_PHY_1M;
-        params.tx_power = 127;    // let the stack pick
-        params.sid = 0;
-        // Standard "fast advertising interval 1" (30-60ms) so the single burst event
-        // (max_events=1 below) fires promptly; the ~2s spacing between bursts comes from
-        // advRestartTimer instead.
-        params.itvl_min = BLE_GAP_ADV_FAST_INTERVAL1_MIN;
-        params.itvl_max = BLE_GAP_ADV_FAST_INTERVAL1_MAX;
-
-        int rc = ble_gap_ext_adv_configure(instance, &params, nullptr, gapEventCallback, this);
-        if (rc != 0) {
-            LOGTE(BLE, "Failed to configure extended advertising: 0x%02x", rc);
-            status = BleStatus::Error;
-            return;
-        }
-
         struct os_mbuf* data = os_msys_get_pkthdr(0, 0);
         if (data == nullptr) {
             LOGTE(BLE, "Failed to allocate mbuf for advertising data");
             status = BleStatus::Error;
-            return;
+            return false;
         }
         rc = ble_hs_adv_set_fields_mbuf(&adFields, data);
         if (rc != 0) {
             LOGTE(BLE, "Failed to encode advertising fields: 0x%02x", rc);
             status = BleStatus::Error;
-            return;
+            return false;
         }
         rc = ble_gap_ext_adv_set_data(instance, data);
         if (rc != 0) {
             LOGTE(BLE, "Failed to set advertising data: 0x%02x", rc);
             status = BleStatus::Error;
-            return;
+            return false;
         }
 
-        rc = ble_gap_ext_adv_start(instance, 0, 1);    // max_events=1: stop after this one burst
-        if (rc != 0 && rc != BLE_HS_EALREADY) {
-            LOGTE(BLE, "Failed to start advertising: 0x%02x", rc);
-            status = BleStatus::Error;
-            return;
-        }
-        status = BleStatus::Advertising;
-        LOGTD(BLE, "Advertising as '%s'", name);
+        advConfigured = true;
+        return true;
     }
 
     const std::string deviceName;
@@ -569,7 +588,8 @@ private:
     int connHandle { -1 };
     bool scanInProgress { false };
     std::string wifiStatus;
-    esp_timer_handle_t advRestartTimer { nullptr };
+    struct ble_npl_callout advRestartCallout { };
+    bool advConfigured { false };    // see startAdvertising(): configure/set-data only needed once
 
     // Ugly Duckling Service — UUID: 100D32C7-A4E6-4F72-8D7A-A61871CE4FD6
     // Bytes stored little-endian (LSB first) as required by NimBLE.

--- a/components/kernel/src/drivers/BleDriver.hpp
+++ b/components/kernel/src/drivers/BleDriver.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <array>
+#include <chrono>
 #include <functional>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <time.h>
 
 #include <esp_random.h>
+#include <esp_timer.h>
 #include <host/ble_gatt.h>
 #include <host/ble_hs.h>    // NOLINT(misc-header-include-cycle) -- ble_hs.h and ble_gap.h include each other; cycle is in ESP-IDF, not our code
 #include <host/ble_hs_mbuf.h>
@@ -21,8 +24,11 @@
 
 #include "WifiApRecord.hpp"
 #include <ArduinoJson.h>
+#include <EspException.hpp>
 #include <Log.hpp>
 #include <NvsStore.hpp>
+
+using namespace std::chrono;
 
 namespace cornucopia::ugly_duckling::kernel::drivers {
 
@@ -73,7 +79,10 @@ public:
         , bleAddr(loadOrGenerateAddress(*nvs)) {
         instance = this;
 
-        nimble_port_init();
+        // Errors from here through the end of the constructor throw (see throwOnBleError):
+        // a device that can't stand up its GATT server or advertise isn't usable, so fail
+        // fast at boot instead of continuing in a silently broken state.
+        ESP_ERROR_THROW(nimble_port_init());
 
         ble_hs_cfg.reset_cb = onReset;
         ble_hs_cfg.sync_cb = onSync;
@@ -92,22 +101,27 @@ public:
         });
 
         // Register the Ugly Duckling custom GATT service (must be before nimble_port_freertos_init)
-        int rc = ble_gatts_count_cfg(gattSvcs);
-        if (rc != 0) {
-            LOGTE(BLE, "ble_gatts_count_cfg failed: 0x%02x", rc);
-        }
-        rc = ble_gatts_add_svcs(gattSvcs);
-        if (rc != 0) {
-            LOGTE(BLE, "ble_gatts_add_svcs failed: 0x%02x", rc);
-        }
+        throwOnBleError(ble_gatts_count_cfg(gattSvcs), "ble_gatts_count_cfg");
+        throwOnBleError(ble_gatts_add_svcs(gattSvcs), "ble_gatts_add_svcs");
 
         // NimBLE DIS stores these pointers directly (no copy), so the strings must remain alive
         // for the device lifetime. They are stored as members below.
-        ble_svc_gap_device_name_set(this->deviceName.c_str());
-        ble_svc_dis_manufacturer_name_set("Cornucopia Machines");
-        ble_svc_dis_model_number_set(this->modelName.c_str());
-        ble_svc_dis_firmware_revision_set(this->firmwareVersion.c_str());
-        ble_svc_dis_serial_number_set(this->serialNumber.c_str());
+        throwOnBleError(ble_svc_gap_device_name_set(this->deviceName.c_str()), "ble_svc_gap_device_name_set");
+        throwOnBleError(ble_svc_dis_manufacturer_name_set("Cornucopia Machines"), "ble_svc_dis_manufacturer_name_set");
+        throwOnBleError(ble_svc_dis_model_number_set(this->modelName.c_str()), "ble_svc_dis_model_number_set");
+        throwOnBleError(ble_svc_dis_firmware_revision_set(this->firmwareVersion.c_str()), "ble_svc_dis_firmware_revision_set");
+        throwOnBleError(ble_svc_dis_serial_number_set(this->serialNumber.c_str()), "ble_svc_dis_serial_number_set");
+
+        // Burst-mode advertising timer — see startAdvertising() and the BLE_GAP_EVENT_ADV_COMPLETE
+        // case in gapEventCallback() for why this exists.
+        esp_timer_create_args_t timerArgs = {
+            .callback = advRestartTimerCallback,
+            .arg = this,
+            .dispatch_method = ESP_TIMER_TASK,
+            .name = "ble-adv-restart",
+            .skip_unhandled_events = true,
+        };
+        ESP_ERROR_THROW(esp_timer_create(&timerArgs, &advRestartTimer));
 
         nimble_port_freertos_init(hostTask);
 
@@ -201,6 +215,20 @@ public:
     }
 
 private:
+    // NimBLE host functions return their own int error codes (BLE_HS_*), not esp_err_t, so
+    // ESP_ERROR_THROW (which calls esp_err_to_name()) doesn't apply. Used only for one-time
+    // initialization in the constructor: a failure there means the device can't function as
+    // designed (no GATT server, no advertising, etc.), so fail fast at boot rather than limp
+    // along silently — unlike runtime paths (notify, restart advertising after disconnect),
+    // which log-and-continue since a transient failure there is expected and recoverable.
+    static void throwOnBleError(int rc, const char* what) {
+        if (rc != 0) {
+            char message[80];
+            snprintf(message, sizeof(message), "%s failed: 0x%02x", what, rc);
+            throw std::runtime_error(message);
+        }
+    }
+
     // Posts a callable onto the NimBLE host task's event queue. All BLE state
     // (wifiStatus, wifiScanResults, connHandle, scanInProgress) is owned by the
     // host task, so this is the only safe way to mutate it from another task.
@@ -259,6 +287,15 @@ private:
         nimble_port_freertos_deinit();
     }
 
+    // Fires advBurstInterval after each advertising burst completes (see
+    // BLE_GAP_EVENT_ADV_COMPLETE). Runs on the esp_timer task, not the NimBLE host task, so
+    // marshal the actual restart through postToHostTask like every other cross-task entry point.
+    static void advRestartTimerCallback(void* arg) {
+        postToHostTask([driver = static_cast<NimBleDriver*>(arg)]() {
+            driver->startAdvertising();
+        });
+    }
+
     void handleSync() {
         ble_hs_id_set_rnd(bleAddr.data());
         startAdvertising();
@@ -288,6 +325,17 @@ private:
                     event->disconnect.reason);
                 driver->startAdvertising();
                 break;
+            case BLE_GAP_EVENT_ADV_COMPLETE: {
+                // The single burst event (max_events=1 in startAdvertising) just finished.
+                // Re-arm after advBurstInterval instead of restarting immediately — see
+                // startAdvertising() for why.
+                esp_timer_stop(driver->advRestartTimer);    // harmless if not currently armed
+                int rc = esp_timer_start_once(driver->advRestartTimer, duration_cast<microseconds>(advBurstInterval).count());
+                if (rc != ESP_OK) {
+                    LOGTE(BLE, "Failed to arm advertising restart timer: 0x%02x", rc);
+                }
+                break;
+            }
             default:
                 break;
         }
@@ -416,6 +464,16 @@ private:
     // old legacy-advertising implementation there's no need to split fields between a
     // primary ad and a separate scan response — flags, name, and all service UUIDs fit
     // in one ble_hs_adv_fields / ble_gap_ext_adv_set_data call.
+    //
+    // Burst mode: fires a single advertising event (max_events=1 below) instead of advertising
+    // continuously, then re-arms via advRestartTimer after advBurstInterval (see
+    // BLE_GAP_EVENT_ADV_COMPLETE in gapEventCallback). Net over-the-air behavior is the same
+    // as continuous 2s-interval advertising — one event every ~2s, still connectable — but the
+    // WiFi/BLE coexistence scheduler on ESP32-C6 selects its scheme based on the BLE controller's
+    // *advertising state*, not actual radio activity: while advertising is enabled at all (even
+    // between 2s-spaced events), coex wakes the chip from light sleep every ~2.8ms to service RF
+    // time slices. Idle-between-bursts avoids that entirely. Measured: ~13 mA continuous vs
+    // ~3 mA bursty with WiFi station + BLE both active.
     void startAdvertising() {
         constexpr uint8_t instance = 0;
         if (ble_gap_ext_adv_active(instance)) {
@@ -448,9 +506,11 @@ private:
         params.secondary_phy = BLE_HCI_LE_PHY_1M;
         params.tx_power = 127;    // let the stack pick
         params.sid = 0;
-        // 2 s interval (3200 × 0.625 ms) — long enough for the CPU to enter light sleep between events
-        params.itvl_min = 3200;
-        params.itvl_max = 3200;
+        // Standard "fast advertising interval 1" (30-60ms) so the single burst event
+        // (max_events=1 below) fires promptly; the ~2s spacing between bursts comes from
+        // advRestartTimer instead.
+        params.itvl_min = BLE_GAP_ADV_FAST_INTERVAL1_MIN;
+        params.itvl_max = BLE_GAP_ADV_FAST_INTERVAL1_MAX;
 
         int rc = ble_gap_ext_adv_configure(instance, &params, nullptr, gapEventCallback, this);
         if (rc != 0) {
@@ -478,7 +538,7 @@ private:
             return;
         }
 
-        rc = ble_gap_ext_adv_start(instance, 0, 0);
+        rc = ble_gap_ext_adv_start(instance, 0, 1);    // max_events=1: stop after this one burst
         if (rc != 0 && rc != BLE_HS_EALREADY) {
             LOGTE(BLE, "Failed to start advertising: 0x%02x", rc);
             status = BleStatus::Error;
@@ -501,11 +561,15 @@ private:
 
     BleStatus status { BleStatus::Idle };
 
+    // Gap between advertising bursts; see startAdvertising().
+    static constexpr auto advBurstInterval = 2s;
+
     // All fields below are only accessed from the NimBLE host task (GAP/GATT callbacks
     // and postToHostTask closures), so no synchronisation is needed.
     int connHandle { -1 };
     bool scanInProgress { false };
     std::string wifiStatus;
+    esp_timer_handle_t advRestartTimer { nullptr };
 
     // Ugly Duckling Service — UUID: 100D32C7-A4E6-4F72-8D7A-A61871CE4FD6
     // Bytes stored little-endian (LSB first) as required by NimBLE.

--- a/components/kernel/src/drivers/BleDriver.hpp
+++ b/components/kernel/src/drivers/BleDriver.hpp
@@ -410,52 +410,75 @@ private:
         return 0;
     }
 
+    // Extended advertising (ble_gap_ext_adv_*, BLE 5.0) instead of legacy (ble_gap_adv_*).
+    // Matches Espressif's power_save reference example, which uses this by default on
+    // ESP32-C6. A single extended AD payload has room for up to 1650 bytes, so unlike the
+    // old legacy-advertising implementation there's no need to split fields between a
+    // primary ad and a separate scan response — flags, name, and all service UUIDs fit
+    // in one ble_hs_adv_fields / ble_gap_ext_adv_set_data call.
     void startAdvertising() {
+        constexpr uint8_t instance = 0;
+        if (ble_gap_ext_adv_active(instance)) {
+            return;
+        }
+
         static const std::array<ble_uuid16_t, 3> serviceUuids16 = { {
             { .u = { .type = BLE_UUID_TYPE_16 }, .value = 0x180A },
             { .u = { .type = BLE_UUID_TYPE_16 }, .value = 0x180F },
             { .u = { .type = BLE_UUID_TYPE_16 }, .value = 0x1805 },
         } };
 
-        // Primary ad: flags + name (26 bytes available after flags' 3B + name header 2B).
         const char* name = ble_svc_gap_device_name();
         struct ble_hs_adv_fields adFields = { };
         adFields.flags = BLE_HS_ADV_F_DISC_GEN | BLE_HS_ADV_F_BREDR_UNSUP;
         adFields.name = reinterpret_cast<const uint8_t*>(name);
-        adFields.name_len = static_cast<uint8_t>(strnlen(name, 26));
-        adFields.name_is_complete = (strnlen(name, 27) <= 26) ? 1 : 0;
+        adFields.name_len = static_cast<uint8_t>(strlen(name));
+        adFields.name_is_complete = 1;
+        adFields.uuids16 = serviceUuids16.data();
+        adFields.num_uuids16 = serviceUuids16.size();
+        adFields.uuids16_is_complete = 1;
+        adFields.uuids128 = &uglyDucklingServiceUuid;
+        adFields.num_uuids128 = 1;
+        adFields.uuids128_is_complete = 1;
 
-        int rc = ble_gap_adv_set_fields(&adFields);
-        if (rc != 0) {
-            LOGTE(BLE, "Failed to set advertising fields: 0x%02x", rc);
-            status = BleStatus::Error;
-            return;
-        }
-
-        // Scan response: 3 × 16-bit UUIDs (8 B) + 1 × 128-bit UUID (18 B) = 26 B of 31 B available.
-        struct ble_hs_adv_fields rspFields = { };
-        rspFields.uuids16 = serviceUuids16.data();
-        rspFields.num_uuids16 = serviceUuids16.size();
-        rspFields.uuids16_is_complete = 1;
-        rspFields.uuids128 = &uglyDucklingServiceUuid;
-        rspFields.num_uuids128 = 1;
-        rspFields.uuids128_is_complete = 1;
-
-        rc = ble_gap_adv_rsp_set_fields(&rspFields);
-        if (rc != 0) {
-            LOGTE(BLE, "Failed to set scan response fields: 0x%02x", rc);
-            status = BleStatus::Error;
-            return;
-        }
-
-        struct ble_gap_adv_params params = { };
-        params.conn_mode = BLE_GAP_CONN_MODE_UND;
-        params.disc_mode = BLE_GAP_DISC_MODE_GEN;
+        struct ble_gap_ext_adv_params params = { };
+        params.connectable = 1;    // must accept CONNECT_IND for phone-based WiFi provisioning
+        params.own_addr_type = BLE_OWN_ADDR_RANDOM;
+        params.primary_phy = BLE_HCI_LE_PHY_1M;
+        params.secondary_phy = BLE_HCI_LE_PHY_1M;
+        params.tx_power = 127;    // let the stack pick
+        params.sid = 0;
         // 2 s interval (3200 × 0.625 ms) — long enough for the CPU to enter light sleep between events
         params.itvl_min = 3200;
         params.itvl_max = 3200;
 
-        rc = ble_gap_adv_start(BLE_OWN_ADDR_RANDOM, nullptr, BLE_HS_FOREVER, &params, gapEventCallback, this);
+        int rc = ble_gap_ext_adv_configure(instance, &params, nullptr, gapEventCallback, this);
+        if (rc != 0) {
+            LOGTE(BLE, "Failed to configure extended advertising: 0x%02x", rc);
+            status = BleStatus::Error;
+            return;
+        }
+
+        struct os_mbuf* data = os_msys_get_pkthdr(0, 0);
+        if (data == nullptr) {
+            LOGTE(BLE, "Failed to allocate mbuf for advertising data");
+            status = BleStatus::Error;
+            return;
+        }
+        rc = ble_hs_adv_set_fields_mbuf(&adFields, data);
+        if (rc != 0) {
+            LOGTE(BLE, "Failed to encode advertising fields: 0x%02x", rc);
+            status = BleStatus::Error;
+            return;
+        }
+        rc = ble_gap_ext_adv_set_data(instance, data);
+        if (rc != 0) {
+            LOGTE(BLE, "Failed to set advertising data: 0x%02x", rc);
+            status = BleStatus::Error;
+            return;
+        }
+
+        rc = ble_gap_ext_adv_start(instance, 0, 0);
         if (rc != 0 && rc != BLE_HS_EALREADY) {
             LOGTE(BLE, "Failed to start advertising: 0x%02x", rc);
             status = BleStatus::Error;

--- a/components/kernel/src/drivers/BleDriver.hpp
+++ b/components/kernel/src/drivers/BleDriver.hpp
@@ -224,7 +224,7 @@ private:
     static void throwOnBleError(int rc, const char* what) {
         if (rc != 0) {
             char message[80];
-            snprintf(message, sizeof(message), "%s failed: 0x%02x", what, rc);
+            (void) snprintf(message, sizeof(message), "%s failed: 0x%02x", what, rc);
             throw std::runtime_error(message);
         }
     }
@@ -476,7 +476,7 @@ private:
     // ~3 mA bursty with WiFi station + BLE both active.
     void startAdvertising() {
         constexpr uint8_t instance = 0;
-        if (ble_gap_ext_adv_active(instance)) {
+        if (ble_gap_ext_adv_active(instance) != 0) {
             return;
         }
 

--- a/components/kernel/src/drivers/BleDriver.hpp
+++ b/components/kernel/src/drivers/BleDriver.hpp
@@ -70,12 +70,14 @@ public:
         const std::string& modelName,
         const std::string& firmwareVersion,
         const std::string& serialNumber,
-        const std::shared_ptr<NvsStore>& nvs)
+        const std::shared_ptr<NvsStore>& nvs,
+        milliseconds advBurstInterval)
         : deviceName(deviceName)
         , modelName(modelName)
         , firmwareVersion(firmwareVersion)
         , serialNumber(serialNumber)
-        , bleAddr(loadOrGenerateAddress(*nvs)) {
+        , bleAddr(loadOrGenerateAddress(*nvs))
+        , advBurstInterval(advBurstInterval) {
         instance = this;
 
         // Errors from here through the end of the constructor throw (see throwOnBleError):
@@ -122,7 +124,8 @@ public:
 
         nimble_port_freertos_init(hostTask);
 
-        LOGTD(BLE, "Initialized, will advertise as '%s'", this->deviceName.c_str());
+        LOGTD(BLE, "Initialized, will advertise as '%s' every %lld ms",
+            this->deviceName.c_str(), this->advBurstInterval.count());
     }
 
     BleStatus getStatus() override {
@@ -326,7 +329,7 @@ private:
                 // startAdvertising() for why. ble_npl_callout_reset both (re)arms the callout
                 // and is safe to call while already pending, so no separate stop-first step.
                 ble_npl_error_t err = ble_npl_callout_reset(
-                    &driver->advRestartCallout, ble_npl_time_ms_to_ticks32(duration_cast<milliseconds>(advBurstInterval).count()));
+                    &driver->advRestartCallout, ble_npl_time_ms_to_ticks32(driver->advBurstInterval.count()));
                 if (err != BLE_NPL_OK) {
                     LOGTE(BLE, "Failed to arm advertising restart callout: 0x%02x", err);
                 }
@@ -572,6 +575,8 @@ private:
     const std::string firmwareVersion;
     const std::string serialNumber;
     const std::array<uint8_t, 6> bleAddr;
+    // Gap between advertising bursts; see startAdvertising()
+    const milliseconds advBurstInterval;
 
     std::function<void(time_t)> onTimeReceived;
     std::function<void()> onWifiScanRequested;
@@ -579,9 +584,6 @@ private:
     std::function<void(std::string)> onWifiControlReceived;
 
     BleStatus status { BleStatus::Idle };
-
-    // Gap between advertising bursts; see startAdvertising().
-    static constexpr auto advBurstInterval = 2s;
 
     // All fields below are only accessed from the NimBLE host task (GAP/GATT callbacks
     // and postToHostTask closures), so no synchronisation is needed.

--- a/components/kernel/src/drivers/BleDriver.hpp
+++ b/components/kernel/src/drivers/BleDriver.hpp
@@ -8,6 +8,15 @@
 #include <string>
 #include <time.h>
 
+#include "WifiApRecord.hpp"
+#include <Log.hpp>
+#include <NvsStore.hpp>
+
+// NimBleDriver and everything it needs from the "bt" component are only available when
+// CONFIG_BT_NIMBLE_ENABLED is set. Spinach (pre-MK10 devices) disables CONFIG_BT_ENABLED
+// entirely — see docs/specs/Bluetooth.md ("Platform support decision") — which drops the
+// bt component's nimble/host include paths, so these headers wouldn't even resolve there.
+#ifdef CONFIG_BT_NIMBLE_ENABLED
 #include <esp_random.h>
 #include <host/ble_gatt.h>
 #include <host/ble_hs.h>    // NOLINT(misc-header-include-cycle) -- ble_hs.h and ble_gap.h include each other; cycle is in ESP-IDF, not our code
@@ -21,17 +30,13 @@
 #include <services/gap/ble_svc_gap.h>
 #include <services/gatt/ble_svc_gatt.h>
 
-#include "WifiApRecord.hpp"
 #include <ArduinoJson.h>
 #include <EspException.hpp>
-#include <Log.hpp>
-#include <NvsStore.hpp>
+#endif
 
 using namespace std::chrono;
 
 namespace cornucopia::ugly_duckling::kernel::drivers {
-
-LOGGING_TAG(BLE, "ble")
 
 enum class BleStatus : std::uint8_t {
     Disabled,
@@ -42,8 +47,10 @@ enum class BleStatus : std::uint8_t {
     Connected
 };
 
-// No-op BLE driver used when BLE is disabled at runtime (settings->bleEnabled = false).
-// All methods are no-ops; getStatus() returns Disabled. Subclassed by NimBleDriver.
+// No-op BLE driver used when BLE is disabled — either at runtime (settings->bleEnabled =
+// false) or entirely at compile time on platforms without CONFIG_BT_NIMBLE_ENABLED (e.g.
+// Spinach, see docs/specs/Bluetooth.md). All methods are no-ops; getStatus() returns
+// Disabled. Subclassed by NimBleDriver where BLE is compiled in.
 class BleDriver {
 public:
     virtual ~BleDriver() = default;
@@ -56,6 +63,10 @@ public:
     virtual void setWifiStatus(const std::string& /*unused*/) {}
     virtual void setScanResults(const std::vector<WifiApRecord>& /*unused*/) {}
 };
+
+#ifdef CONFIG_BT_NIMBLE_ENABLED
+
+LOGGING_TAG(BLE, "ble")
 
 // Starts NimBLE, advertises the device, and hosts standard GATT services readable with any BLE
 // scanner app (nRF Connect, LightBlue, etc.) without a custom client:
@@ -721,5 +732,7 @@ private:
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     inline static NimBleDriver* instance = nullptr;
 };
+
+#endif    // CONFIG_BT_NIMBLE_ENABLED
 
 }    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/cspell.json
+++ b/cspell.json
@@ -8,6 +8,7 @@
     "Catch2",
     "ccache",
     "clangd",
+    "COEX",
     "constexpr",
     "COPROC",
     "cornucopia",

--- a/docs/specs/Bluetooth.md
+++ b/docs/specs/Bluetooth.md
@@ -8,10 +8,52 @@ disconnect it immediately restarts advertising.
 
 Platforms:
 
-| Platform | SoC      | BLE Support |
-| -------- | -------- | ----------- |
-| Carrot   | ESP32-C6 | Yes         |
-| Spinach  | ESP32-S3 | Yes         |
+| Platform | SoC      | BLE Support    |
+| -------- | -------- | -------------- |
+| Carrot   | ESP32-C6 | Yes            |
+| Spinach  | ESP32-S3 | No (see below) |
+
+### Platform support decision
+
+BLE is **fully disabled on Spinach** (pre-MK10 devices — MK5 through MK9), both
+at the sdkconfig level (`CONFIG_BT_ENABLED=n` in `sdkconfig.spinach.defaults`,
+overriding `sdkconfig.defaults`' `CONFIG_BT_ENABLED=y` for this platform only)
+and in application code (everything depending on NimBLE is compiled out under
+`#ifdef CONFIG_BT_NIMBLE_ENABLED` — see [Driver Architecture](#driver-architecture)).
+
+Rationale: proper BLE support (WiFi provisioning, local-only mode, etc.) matters
+for **new** devices going forward — Carrot (MK10+). Pre-MK10 devices keep their
+existing provisioning path (SoftAP/USB) and data transfer path (WiFi/MQTT) and
+don't need BLE at all, so there's no reason to carry it — including debugging
+ESP32-S3-specific BLE controller quirks (community reports suggest its BLE
+controller shares lineage with the older, more constrained ESP32-C3 rather than
+the newer C6/H2 stack, and that connectable extended advertising is less
+reliable there — not confirmed on this codebase, since the investigation was
+abandoned in favor of this decision). Disabling BLE at compile time also
+recovers flash/RAM otherwise spent on `libble_app.a` and the NimBLE host task on
+these older, more resource-constrained boards.
+
+If a pre-MK10 device ever needs BLE after all, re-enable
+`CONFIG_BT_ENABLED`/`CONFIG_BT_NIMBLE_ENABLED` (and the rest of the Bluetooth
+block from `sdkconfig.defaults`) in `sdkconfig.spinach.defaults`, then revisit
+the ESP32-S3 connectable-extended-advertising question above before shipping.
+
+**Alternative considered — drop back to legacy advertising:** switching from
+BLE 5.0 extended advertising to legacy advertising (`ble_gap_adv_*` instead of
+`ble_gap_ext_adv_*` — see the [compatibility note](#advertising) above) is a
+separate option, not chosen here but still open, primarily to address Android
+extended-advertising support being a per-chipset hardware property rather than
+guaranteed by API level. It would mean reintroducing the primary-ad/scan-response
+split (31 bytes each) since legacy PDUs can't carry today's merged payload
+(name + 3×16-bit UUIDs + 1×128-bit UUID). It's also plausible (though
+unconfirmed — see above) that legacy PDUs sidestep the ESP32-S3
+connectable-extended-advertising reliability question entirely, since that
+issue is specific to the extended, non-legacy PDU path. **If we do make this
+switch, Spinach/ESP32-S3 BLE support is worth reconsidering** — the S3
+rationale for staying with extended advertising falls away once legacy PDUs
+are back in play, though the "why bother, older devices don't need it"
+argument from the decision above would still need to be re-evaluated
+independently.
 
 ---
 
@@ -35,9 +77,9 @@ to 1650 bytes, so — unlike legacy advertising's 31-byte primary + 31-byte
 scan-response split — flags, device name, and all service UUIDs fit in one
 payload; there is no separate scan response.
 
-| PDU                      | Contents                                                          |
-| ------------------------ | ------------------------------------------------------------------ |
-| Extended advertising ad  | Flags + device name + complete list of 16-bit and 128-bit UUIDs   |
+| PDU                     | Contents                                                        |
+| ----------------------- | --------------------------------------------------------------- |
+| Extended advertising ad | Flags + device name + complete list of 16-bit and 128-bit UUIDs |
 
 Service UUIDs included:
 
@@ -51,7 +93,7 @@ Service UUIDs included:
 > **Compatibility note:** extended advertising is a real BLE 5.0 controller
 > capability, not universally supported by every phone or scanner app. iOS
 > requires **iPhone XS or later, iOS 13+** (iPhone X, released the same year
-> as BT5 hardware shipped, is *not* included — the cutover is specifically
+> as BT5 hardware shipped, is _not_ included — the cutover is specifically
 > XS/XR); Apple caps extended AD data it reads at 124 bytes. Android has the
 > scanning API since 8.0 (API 26), but actual support is a **per-chipset
 > hardware property** (`BluetoothAdapter.isLeExtendedAdvertisingSupported()`)
@@ -71,7 +113,7 @@ Advertising fires in **single-event bursts** roughly every 2 s, rather than
 advertising continuously with a 2 s interval. See
 [WiFi/BLE Coexistence & Power](#wifible-coexistence--power) below for why —
 in short, the ESP32-C6's WiFi/BLE coexistence scheduler picks its (expensive)
-scheme based on whether the controller's advertising *state* is enabled at
+scheme based on whether the controller's advertising _state_ is enabled at
 all, not on the actual on-air event cadence, so continuous advertising (even
 at a slow interval) keeps the coexistence scheduler engaged and the chip
 waking from light sleep constantly.
@@ -95,7 +137,7 @@ Mechanics (`BleDriver::startAdvertising()` /
 
 Net over-the-air behavior is unchanged from continuous 2 s-interval
 advertising — one connectable event roughly every 2 s — only the controller's
-state *between* events differs (idle instead of continuously enabled).
+state _between_ events differs (idle instead of continuously enabled).
 
 ---
 
@@ -148,6 +190,15 @@ Callbacks wired in `Device.hpp`:
 `BleDriver` (`components/kernel/src/drivers/BleDriver.hpp`) owns the NimBLE
 lifecycle:
 
+- `BleDriver` itself is a no-op base class (`getStatus()` always returns
+  `Disabled`) with no NimBLE dependency, so it's always available. Its subclass
+  `NimBleDriver` — and every NimBLE header it needs — is compiled only under
+  `#ifdef CONFIG_BT_NIMBLE_ENABLED`, since on platforms where the option is off
+  (Spinach — see [Platform support decision](#platform-support-decision)) the
+  `bt` component doesn't even expose the nimble/host include paths. `Device.hpp`
+  mirrors the same `#ifdef`: it only instantiates `NimBleDriver` (gated further
+  by `settings->bleEnabled` at runtime) inside the guard, falling back to the
+  no-op `BleDriver` unconditionally outside it.
 - Constructed in `Device.hpp` before WiFi, passing device name, model, firmware
   version, serial number, and an `NvsStore` for address persistence.
 - Constructor errors (NimBLE init, GATT service registration, GAP/DIS field
@@ -207,13 +258,13 @@ rather than hardware wakeup) is an untested, separate avenue for the same
 "receive beacons without a full CPU wake" goal — worth investigating if beacon
 lost handling ever needs improving, but do not assume it has the same problem.
 
-### Root cause 2 — coexistence scheduler keyed on advertising *state*, not on-air activity
+### Root cause 2 — coexistence scheduler keyed on advertising _state_, not on-air activity
 
 With root cause 1 fixed, WiFi-only and BLE-only were both cheap (~2 mA and
 ~1.3 mA respectively, even with BLE's 2 s advertising interval) — but WiFi
 **and** BLE together still drew ~13 mA. The deciding experiment: BLE advertising
 alone was cheap regardless of interval, so the expense wasn't about how often
-an actual advertising PDU went out — it was specifically about having *both*
+an actual advertising PDU went out — it was specifically about having _both_
 radios active together. That pointed at the coexistence (coex) scheduler.
 
 Espressif's coexistence documentation confirms the mechanism: when WiFi STA is
@@ -222,7 +273,7 @@ Transmission Time — the AP's beacon interval, typically ~100 ms) —
 independent of BLE's `listen_interval` or advertising interval. This matched
 a periodic ETSTimer pair found via `esp_timer_dump()` firing roughly every
 ~105 ms. The controller was, in effect, choosing its (expensive) coexistence
-scheme based on whether BLE advertising was *enabled at all*, not on the
+scheme based on whether BLE advertising was _enabled at all_, not on the
 actual cadence of advertising events — so even a slow, infrequent advertiser
 kept the coex scheduler engaged continuously, waking the chip from light sleep
 every ~2.8 ms to service RF time slices.
@@ -236,7 +287,7 @@ advertising vs. ~3-3.25 mA bursty, WiFi + BLE both active in both cases.
 
 ### A crash along the way — NimBLE host crash under WiFi+MQTT+TLS load
 
-The first burst-mode implementation re-ran the *entire* advertising setup
+The first burst-mode implementation re-ran the _entire_ advertising setup
 (`ble_gap_ext_adv_configure()` + mbuf alloc + `ble_gap_ext_adv_set_data()` +
 `ble_gap_ext_adv_start()`) on every ~2 s burst. `ble_gap_ext_adv_configure()`
 and `ble_gap_ext_adv_set_data()` are real HCI round-trips to the controller,
@@ -280,7 +331,7 @@ from the redundant per-burst reconfiguration.
 Ruled out during root cause 2's investigation, on this codebase:
 
 - WiFi/coexistence in general — reproduces identically with WiFi driver never
-  initialized at all (rules out coexistence as *root cause 1*'s mechanism;
+  initialized at all (rules out coexistence as _root cause 1_'s mechanism;
   root cause 2 specifically requires both radios active, see above).
 - NimBLE `Central`/`Observer` roles — disabling both (`CONFIG_BT_NIMBLE_ROLE_CENTRAL=n`,
   `CONFIG_BT_NIMBLE_ROLE_OBSERVER=n`; kept disabled regardless, since we never
@@ -292,7 +343,7 @@ Ruled out during root cause 2's investigation, on this codebase:
   problem (extended advertising was kept anyway, for larger-payload headroom;
   see the compatibility note above).
 - `CONFIG_PM_LIGHTSLEEP_RTC_OSC_CAL_INTERVAL` (16 vs. default 1) — changed the
-  *shape* of the numbers (fewer wakeups, worse sleep ratio) but not the
+  _shape_ of the numbers (fewer wakeups, worse sleep ratio) but not the
   underlying problem.
 - `CONFIG_PM_LIGHT_SLEEP_CALLBACKS` — disabling entirely made no difference.
 - A deliberately slow `esp_pm` light-sleep callback (busy-wait in `enter_cb`,
@@ -321,7 +372,7 @@ from `sdkconfig`):
   effect (lock/sleep numbers stayed within noise of the default
   `PREFER_BALANCE`).
 - Lowering max CPU frequency 160→80 MHz — negligible effect; wakeup
-  *frequency* is what mattered, not clock speed during each wake.
+  _frequency_ is what mattered, not clock speed during each wake.
 - Espressif's coexistence doc's "Wi-Fi Connectionless Modules Coexistence"
   section (Window/Interval parameters) looked promising but turned out to be
   about ESP-NOW/DPP/FTM, not a plain WiFi-STA + BLE-advertising setup — a red
@@ -333,7 +384,7 @@ from `sdkconfig`):
   `CONFIG_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP` was pulled in alongside
   `ESP_WIFI_ENHANCED_LIGHT_SLEEP` during the original investigation and never
   isolated on its own; still commented out (`# TODO Experiment with this
-  separately`) in `sdkconfig.defaults`.
+separately`) in `sdkconfig.defaults`.
 - File an upstream ESP-IDF issue for the `ESP_WIFI_ENHANCED_LIGHT_SLEEP` +
   BLE interaction once reproduced on a minimal example.
 - `SLP_SAMPLE_BEACON_FEATURE` (see root cause 1) as an alternative to the

--- a/docs/specs/Bluetooth.md
+++ b/docs/specs/Bluetooth.md
@@ -29,14 +29,17 @@ hostname (e.g. `ugly-duckling-aabbcc`).
 
 ## Advertising
 
-Two PDUs are sent on each advertising interval (2 s, fixed):
+Uses **BLE 5.0 extended advertising** (`ble_gap_ext_adv_*`, `CONFIG_BT_NIMBLE_EXT_ADV=y`)
+rather than legacy advertising. A single extended AD payload has room for up
+to 1650 bytes, so — unlike legacy advertising's 31-byte primary + 31-byte
+scan-response split — flags, device name, and all service UUIDs fit in one
+payload; there is no separate scan response.
 
-| PDU           | Contents                              |
-| ------------- | ------------------------------------- |
-| Primary ad    | Flags + device name (up to 26 bytes)  |
-| Scan response | Complete list of 16-bit service UUIDs |
+| PDU                      | Contents                                                          |
+| ------------------------ | ------------------------------------------------------------------ |
+| Extended advertising ad  | Flags + device name + complete list of 16-bit and 128-bit UUIDs   |
 
-Service UUIDs included in the scan response:
+Service UUIDs included:
 
 | UUID                                   | Service                        |
 | -------------------------------------- | ------------------------------ |
@@ -45,10 +48,54 @@ Service UUIDs included in the scan response:
 | 0x1805                                 | Current Time (CTS)             |
 | `100D32C7-A4E6-4F72-8D7A-A61871CE4FD6` | Ugly Duckling Service (custom) |
 
-The three standard 16-bit UUIDs together occupy 3 × 2 + 1 (type) + 1 (length)
-= 8 bytes. The one 128-bit custom UUID adds 16 + 2 = 18 bytes. Total: 26 bytes
-out of the 31-byte scan-response PDU — no room for additional custom UUIDs,
-which is why all custom functionality goes into a single service.
+> **Compatibility note:** extended advertising is a real BLE 5.0 controller
+> capability, not universally supported by every phone or scanner app. iOS
+> requires **iPhone XS or later, iOS 13+** (iPhone X, released the same year
+> as BT5 hardware shipped, is *not* included — the cutover is specifically
+> XS/XR); Apple caps extended AD data it reads at 124 bytes. Android has the
+> scanning API since 8.0 (API 26), but actual support is a **per-chipset
+> hardware property** (`BluetoothAdapter.isLeExtendedAdvertisingSupported()`)
+> independent of Android version — some current-generation budget phones still
+> return `false`. In practice, **nRF Connect failed to show the device name**
+> (`N/A`) when we switched to extended advertising, while **LightBlue and the
+> Ugly Duckling companion app (iOS) both work correctly** — the failure mode is
+> app/OS-specific parsing support, not malformed advertising data. If broad
+> Android compatibility becomes a requirement, NimBLE supports running a
+> second, legacy-PDU advertising set concurrently (`ble_gap_ext_adv_params.legacy_pdu`,
+> or a second advertising instance via `CONFIG_BT_NIMBLE_MAX_EXT_ADV_INSTANCES`)
+> — not implemented, since the companion app is the primary provisioning path.
+
+### Burst-mode advertising (power)
+
+Advertising fires in **single-event bursts** roughly every 2 s, rather than
+advertising continuously with a 2 s interval. See
+[WiFi/BLE Coexistence & Power](#wifible-coexistence--power) below for why —
+in short, the ESP32-C6's WiFi/BLE coexistence scheduler picks its (expensive)
+scheme based on whether the controller's advertising *state* is enabled at
+all, not on the actual on-air event cadence, so continuous advertising (even
+at a slow interval) keeps the coexistence scheduler engaged and the chip
+waking from light sleep constantly.
+
+Mechanics (`BleDriver::startAdvertising()` /
+`BleDriver::configureAndSetData()`):
+
+1. Advertising parameters and AD payload are configured **once** via
+   `ble_gap_ext_adv_configure()` + `ble_gap_ext_adv_set_data()` — both are HCI
+   round-trips to the controller, not local struct updates, and neither
+   changes between bursts, so repeating them is pure (and, as discovered, not
+   harmless) overhead.
+2. Each burst is a single advertising event: `ble_gap_ext_adv_start(instance, 0, 1)`
+   (`max_events=1`), at the standard "fast advertising interval 1" range
+   (`BLE_GAP_ADV_FAST_INTERVAL1_MIN`/`_MAX`, 30-60 ms) so the one event fires
+   promptly.
+3. On `BLE_GAP_EVENT_ADV_COMPLETE`, a `ble_npl_callout` (initialized against
+   NimBLE's own host event queue, so its callback runs directly on the host
+   task with no cross-task marshaling) re-arms for ~2 s, then restarts the
+   next burst.
+
+Net over-the-air behavior is unchanged from continuous 2 s-interval
+advertising — one connectable event roughly every 2 s — only the controller's
+state *between* events differs (idle instead of continuously enabled).
 
 ---
 
@@ -103,13 +150,194 @@ lifecycle:
 
 - Constructed in `Device.hpp` before WiFi, passing device name, model, firmware
   version, serial number, and an `NvsStore` for address persistence.
+- Constructor errors (NimBLE init, GATT service registration, GAP/DIS field
+  setters) **throw** rather than log-and-continue — a device that can't stand
+  up its GATT server or advertise isn't usable, so it fails fast at boot.
+  NimBLE host functions return their own `int` error codes (`BLE_HS_*`), not
+  `esp_err_t`, so a small `throwOnBleError()` helper is used alongside
+  `ESP_ERROR_THROW` (for the genuine `esp_err_t`-returning calls, e.g.
+  `nimble_port_init()`). Runtime paths (notify, restart-advertising-after-
+  disconnect) still log-and-continue, since a transient failure there is
+  expected and recoverable.
 - A FreeRTOS task (`hostTask`) runs the NimBLE host loop.
 - `onSync` → calls `ble_hs_id_set_rnd()` then `startAdvertising()`.
-- `gapEventCallback` handles connect/disconnect and restarts advertising on
-  disconnect.
+- `startAdvertising()` / `configureAndSetData()` implement burst-mode
+  advertising — see [Burst-mode advertising (power)](#burst-mode-advertising-power).
+- `gapEventCallback` handles connect/disconnect (restarts advertising) and
+  `BLE_GAP_EVENT_ADV_COMPLETE` (re-arms the next burst).
 - `BleStatus` enum: `Idle | Resetting | Error | Advertising | Connected`.
 - The single global `instance` pointer allows static C callbacks to dispatch
   back to the driver instance.
+
+---
+
+## WiFi/BLE Coexistence & Power
+
+Enabling BLE (`DeviceSettings.bleEnabled = true`) on MK11 (ESP32-C6) originally
+pushed average current from ~3 mA to ~13 mA — far more than periodic
+advertising should cost. Root-causing this took a long investigation across
+two builds — this codebase and a scratch copy of Espressif's
+`nimble/power_save` example — since the SoC and IDF version were never the
+problem; specific configuration and application-level choices were. Two
+independent root causes were found and fixed; a third issue (a crash)
+surfaced while fixing the second and was fixed in turn.
+
+### Root cause 1 — `CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP`
+
+This option ("hardware-assisted beacon reception during light sleep: the WiFi
+modem wakes autonomously for each beacon interval, keeping the CPU in light
+sleep until actual data arrives"; C6-specific, requires
+`SOC_PM_SUPPORT_BEACON_WAKEUP`) sounds purely beneficial, and was enabled
+expecting a power improvement. Instead, with BLE also active, it made
+`esp_light_sleep_start()` reject **100% of attempts** — confirmed via
+`esp_pm`'s `light_sleep_counts`/`light_sleep_reject_counts` (`CONFIG_PM_PROFILING=y`)
+staying at `light_sleep_counts:0` for the whole run — even with WiFi never
+connected. The elevated current came from constantly attempting and aborting
+light sleep, not from short-but-real sleep cycles. Measured impact on MK11:
+~33 mA with the option enabled vs. ~4 mA disabled, BLE advertising in both
+cases. Root-caused by bisecting a full `sdkconfig` diff against the
+`power_save` reference example (which does not enable this option) down to
+this single setting.
+
+**Fix:** keep `CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP` disabled — see the
+detailed comment in `sdkconfig.carrot.defaults`. Not filed upstream yet (TODO:
+reproduce on a minimal example and file an ESP-IDF issue). The mutually
+exclusive `SLP_SAMPLE_BEACON_FEATURE` (beacon timing calibration via sampling,
+rather than hardware wakeup) is an untested, separate avenue for the same
+"receive beacons without a full CPU wake" goal — worth investigating if beacon
+lost handling ever needs improving, but do not assume it has the same problem.
+
+### Root cause 2 — coexistence scheduler keyed on advertising *state*, not on-air activity
+
+With root cause 1 fixed, WiFi-only and BLE-only were both cheap (~2 mA and
+~1.3 mA respectively, even with BLE's 2 s advertising interval) — but WiFi
+**and** BLE together still drew ~13 mA. The deciding experiment: BLE advertising
+alone was cheap regardless of interval, so the expense wasn't about how often
+an actual advertising PDU went out — it was specifically about having *both*
+radios active together. That pointed at the coexistence (coex) scheduler.
+
+Espressif's coexistence documentation confirms the mechanism: when WiFi STA is
+connected, the coexistence period is anchored to **TBTT** (Target Beacon
+Transmission Time — the AP's beacon interval, typically ~100 ms) —
+independent of BLE's `listen_interval` or advertising interval. This matched
+a periodic ETSTimer pair found via `esp_timer_dump()` firing roughly every
+~105 ms. The controller was, in effect, choosing its (expensive) coexistence
+scheme based on whether BLE advertising was *enabled at all*, not on the
+actual cadence of advertising events — so even a slow, infrequent advertiser
+kept the coex scheduler engaged continuously, waking the chip from light sleep
+every ~2.8 ms to service RF time slices.
+
+**Fix:** burst-mode advertising — see
+[Burst-mode advertising (power)](#burst-mode-advertising-power) above. Firing
+single-event bursts and leaving the controller idle (not "enabled") between
+bursts starves the coex scheduler's reason to keep the chip awake, since the
+scheduler reacts to state, not cadence. Measured: ~13 mA continuous
+advertising vs. ~3-3.25 mA bursty, WiFi + BLE both active in both cases.
+
+### A crash along the way — NimBLE host crash under WiFi+MQTT+TLS load
+
+The first burst-mode implementation re-ran the *entire* advertising setup
+(`ble_gap_ext_adv_configure()` + mbuf alloc + `ble_gap_ext_adv_set_data()` +
+`ble_gap_ext_adv_start()`) on every ~2 s burst. `ble_gap_ext_adv_configure()`
+and `ble_gap_ext_adv_set_data()` are real HCI round-trips to the controller,
+not local struct updates — and neither the advertising parameters nor the AD
+payload (name, UUIDs) ever change between bursts, so this was pure redundant
+HCI traffic, piling onto an already-busy HCI event path. Under real WiFi STA,
+MQTT, and TLS handshake load, this crashed the NimBLE host a few seconds
+after boot:
+
+```
+assertion:event
+line:103,function:npl_freertos_event_init
+Guru Meditation Error: Core  0 panic'ed (Store access fault).
+...
+ble_hs_event_rx_hci_ev at .../nimble/host/src/ble_hs.c:644
+```
+
+— NimBLE's own HCI-event-receive path handed `npl_freertos_event_init` a
+NULL/bad event pointer, consistent with NPL/HCI event pool exhaustion
+(`CONFIG_BT_NIMBLE_TRANSPORT_EVT_COUNT`, default 30) once the host task got
+starved during the CPU-heavy TLS handshake while HCI events kept accumulating
+from the redundant per-burst reconfiguration.
+
+**Fix**, in `BleDriver::startAdvertising()` / `configureAndSetData()`:
+
+1. Configure the advertising set (params + AD payload) **once**, guarded by
+   `advConfigured`. Every burst after the first calls only
+   `ble_gap_ext_adv_start()`.
+2. Replaced the burst-restart `esp_timer` with a `ble_npl_callout`
+   initialized against NimBLE's own host event queue
+   (`nimble_port_get_dflt_eventq()`) — its callback runs directly on the host
+   task, removing a cross-task hop (esp_timer task → manual marshaling → host
+   task) that was a contributing factor under load.
+3. `CONFIG_BT_NIMBLE_TRANSPORT_EVT_COUNT` 30→60 and
+   `CONFIG_BT_NIMBLE_TRANSPORT_EVT_DISCARD_COUNT` 8→16, as headroom against
+   the same failure mode recurring under other bursts of HCI activity — not
+   the fix itself, insurance alongside it.
+
+### Investigative dead ends
+
+Ruled out during root cause 2's investigation, on this codebase:
+
+- WiFi/coexistence in general — reproduces identically with WiFi driver never
+  initialized at all (rules out coexistence as *root cause 1*'s mechanism;
+  root cause 2 specifically requires both radios active, see above).
+- NimBLE `Central`/`Observer` roles — disabling both (`CONFIG_BT_NIMBLE_ROLE_CENTRAL=n`,
+  `CONFIG_BT_NIMBLE_ROLE_OBSERVER=n`; kept disabled regardless, since we never
+  scan or connect out) made no difference. Also rules out background scanning
+  as a contributor.
+- GATT services (DIS/BAS/CTS/custom) — disabling all of them, bare advertising
+  only, made no difference.
+- Legacy vs. extended advertising API choice — made no difference to the power
+  problem (extended advertising was kept anyway, for larger-payload headroom;
+  see the compatibility note above).
+- `CONFIG_PM_LIGHTSLEEP_RTC_OSC_CAL_INTERVAL` (16 vs. default 1) — changed the
+  *shape* of the numbers (fewer wakeups, worse sleep ratio) but not the
+  underlying problem.
+- `CONFIG_PM_LIGHT_SLEEP_CALLBACKS` — disabling entirely made no difference.
+- A deliberately slow `esp_pm` light-sleep callback (busy-wait in `enter_cb`,
+  tested on the reference example) — did not reproduce the reject storm,
+  ruling out light-sleep-callback overhead as a mechanism.
+- PM lock hold times (`CONFIG_PM_PROFILING=y`) and `esp_timer` usage
+  (`CONFIG_ESP_TIMER_PROFILING=y`) — nothing held/scheduled anywhere near the
+  observed wakeup rate.
+- Per-task CPU time (`CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y`) — no single
+  task was CPU-hogging; the reject loop runs inside the idle task itself
+  (`vApplicationSleep`), which is why task-level stats couldn't show a
+  "culprit task."
+
+Ruled out during root cause 2's investigation, on the `nimble/power_save`
+reference example (a separate, scratch copy used to isolate application code
+from `sdkconfig`):
+
+- Initial hypothesis carried over from the real-firmware investigation was
+  that BLE's controller wakes on an inherent ~1 ms hardware cadence regardless
+  of anything else. Once BLE-alone measured a clean 255-600 µA on the
+  reference example, that theory didn't hold — the culprit was
+  coexistence-specific, only appearing when both radios were live.
+- `esp_wifi_set_ps(WIFI_PS_MAX_MODEM)` + `listen_interval=20` — helped a
+  little (13 mA → ~12 mA) but nowhere near enough.
+- `esp_coex_preference_set(ESP_COEX_PREFER_BT)` — measured essentially zero
+  effect (lock/sleep numbers stayed within noise of the default
+  `PREFER_BALANCE`).
+- Lowering max CPU frequency 160→80 MHz — negligible effect; wakeup
+  *frequency* is what mattered, not clock speed during each wake.
+- Espressif's coexistence doc's "Wi-Fi Connectionless Modules Coexistence"
+  section (Window/Interval parameters) looked promising but turned out to be
+  about ESP-NOW/DPP/FTM, not a plain WiFi-STA + BLE-advertising setup — a red
+  herring.
+
+### Open follow-ups
+
+- [Issue #593](https://github.com/cornucopia-machines/ugly-duckling-firmware/issues/593) —
+  `CONFIG_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP` was pulled in alongside
+  `ESP_WIFI_ENHANCED_LIGHT_SLEEP` during the original investigation and never
+  isolated on its own; still commented out (`# TODO Experiment with this
+  separately`) in `sdkconfig.defaults`.
+- File an upstream ESP-IDF issue for the `ESP_WIFI_ENHANCED_LIGHT_SLEEP` +
+  BLE interaction once reproduced on a minimal example.
+- `SLP_SAMPLE_BEACON_FEATURE` (see root cause 1) as an alternative to the
+  disabled hardware beacon-wakeup option — unexplored.
 
 ---
 

--- a/sdkconfig.carrot.defaults
+++ b/sdkconfig.carrot.defaults
@@ -3,6 +3,11 @@
 #
 CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
 
+# Use external 32.768 kHz crystal on GPIO4/5 (MK11+) for RTC clock source.
+# This is required for BLE connections to peers when using light sleep.
+# For MK10 the firmware will fall back to the internal 136 kHz RC oscillator.
+CONFIG_RTC_CLK_SRC_EXT_CRYS=y
+
 #
 # Wi-Fi
 #
@@ -23,6 +28,7 @@ CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP=y
 # switch to BT_LE_LP_CLK_SRC_DEFAULT for both lower power and spec-compliant connections. See issue #576.
 #
 CONFIG_BT_LE_SLEEP_ENABLE=y
+CONFIG_BT_LE_LP_CLK_SRC_DEFAULT=y
 
 #
 # LP core coprocessor (used for pulse counting during light sleep)

--- a/sdkconfig.carrot.defaults
+++ b/sdkconfig.carrot.defaults
@@ -3,7 +3,7 @@
 #
 CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
 
-# Use external 32.768 kHz crystal on GPIO4/5 (MK11+) for RTC clock source.
+# Use external 32.768 kHz crystal on GPIO0/1 (MK11+) for RTC clock source.
 # This is required for BLE connections to peers when using light sleep.
 # For MK10 the firmware will fall back to the internal 136 kHz RC oscillator.
 CONFIG_RTC_CLK_SRC_EXT_CRYS=y

--- a/sdkconfig.carrot.defaults
+++ b/sdkconfig.carrot.defaults
@@ -3,8 +3,9 @@
 #
 CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
 
-# Use external 32.768 kHz crystal on GPIO0/1 (MK11+) for RTC clock source.
-# This is required for BLE connections to peers when using light sleep.
+# Use external 32.768 kHz crystal on GPIO0/1 (MK11+) for RTC clock source. This is what
+# lets BT_LE_LP_CLK_SRC_DEFAULT below use the RTC slow clock (accurate, low-power) as BLE's
+# low-power clock instead of keeping the main XTAL powered during light sleep.
 # For MK10 the firmware will fall back to the internal 136 kHz RC oscillator.
 CONFIG_RTC_CLK_SRC_EXT_CRYS=y
 
@@ -12,20 +13,31 @@ CONFIG_RTC_CLK_SRC_EXT_CRYS=y
 # Wi-Fi
 #
 
-# Hardware-assisted beacon reception during light sleep: the WiFi modem wakes autonomously
-# for each beacon interval, keeping the CPU in light sleep until actual data arrives.
-# C6-specific (requires SOC_PM_SUPPORT_BEACON_WAKEUP, not available on S3).
-# Mutually exclusive with SLP_SAMPLE_BEACON_FEATURE (beacon timing calibration).
-CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP=y
+# DO NOT ENABLE CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP. Its own description sounds
+# harmless/beneficial ("hardware-assisted beacon reception during light sleep: the WiFi
+# modem wakes autonomously for each beacon interval, keeping the CPU in light sleep until
+# actual data arrives"; C6-specific, requires SOC_PM_SUPPORT_BEACON_WAKEUP), but when BLE
+# is also enabled it silently breaks light sleep entirely: esp_light_sleep_start() starts
+# rejecting ~100% of attempts (confirmed via esp_pm's light_sleep_counts/
+# light_sleep_reject_counts, CONFIG_PM_PROFILING=y), even with WiFi never connected —
+# apparently this option's hardware beacon-wakeup registration collides with BT's own
+# esp_sleep_enable_bt_wakeup() RTC/PMU wakeup source. Measured impact on MK11: ~33 mA
+# average with this enabled vs ~4 mA with it disabled, BLE advertising in both cases.
+# Root-caused 2026-07-13 by bisecting a full sdkconfig diff against Espressif's
+# nimble/power_save example, which does not enable this option. Not filed upstream yet —
+# TODO: file an ESP-IDF issue once reproduced on a minimal example.
+# Mutually exclusive with SLP_SAMPLE_BEACON_FEATURE (beacon timing calibration) — that
+# option remains an open, separate avenue for the same "receive beacons without a full
+# CPU wake" goal and hasn't been tested; do not assume it has the same problem.
+# CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP=y
 
 #
 # BLE controller sleep — allows light sleep between advertising events (C6-specific config name).
-# We keep BT_LE_LP_CLK_SRC_MAIN_XTAL (ESP-IDF default): the main XTAL stays powered during light
-# sleep, which keeps clock accuracy within the BLE-spec 500 PPM limit needed for phone connections.
-# Switching to BT_LE_LP_CLK_SRC_DEFAULT (136 kHz RC) would save a little more power but the RC
-# exceeds 500 PPM, making connections to non-ESP peers (e.g. phones) unreliable.
-# When CONFIG_RTC_CLK_SRC_EXT_CRYS=y is set (32.768 kHz crystal on GPIO4/5, MK11+),
-# switch to BT_LE_LP_CLK_SRC_DEFAULT for both lower power and spec-compliant connections. See issue #576.
+# ESP-IDF defaults to BT_LE_LP_CLK_SRC_MAIN_XTAL (keeps the main XTAL powered during light sleep),
+# recommended when no external 32.768 kHz crystal is available. Since CONFIG_RTC_CLK_SRC_EXT_CRYS=y
+# above gives us one (MK11+), we use BT_LE_LP_CLK_SRC_DEFAULT (the RTC slow clock, i.e. that same
+# crystal) instead — lower power than the main XTAL, and still within the BLE-spec 500 PPM sleep
+# clock accuracy limit needed for reliable connections to phones/non-ESP peers. See issue #576.
 #
 CONFIG_BT_LE_SLEEP_ENABLE=y
 CONFIG_BT_LE_LP_CLK_SRC_DEFAULT=y

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -167,6 +167,14 @@ CONFIG_BT_NIMBLE_SVC_DIS_SERIAL_NUMBER=y
 # service UUIDs) without needing a separate scan response.
 CONFIG_BT_NIMBLE_EXT_ADV=y
 
+# Headroom for the NPL/HCI event pool (defaults: COUNT=30, DISCARD_COUNT=8). Not the fix for
+# the burst-advertising crash documented in BleDriver::startAdvertising (that's the
+# configure-once change) — this is insurance against the same failure mode (apparent event
+# pool exhaustion under sustained WiFi+MQTT+TLS load) recurring under other bursts of HCI
+# activity we haven't hit yet.
+CONFIG_BT_NIMBLE_TRANSPORT_EVT_COUNT=60
+CONFIG_BT_NIMBLE_TRANSPORT_EVT_DISCARD_COUNT=16
+
 # Wi-Fi + BLE coexistence
 CONFIG_ESP_COEX_SW_COEXIST_ENABLE=y
 # Power management for Wi-Fi + BLE coexistence

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -61,7 +61,7 @@ CONFIG_PM_SLP_DISABLE_GPIO=y
 CONFIG_ESP_SLEEP_POWER_DOWN_FLASH=y
 CONFIG_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP=y
 CONFIG_PM_RESTORE_CACHE_TAGMEM_AFTER_LIGHT_SLEEP=y
-# TODO Experiment with this separately — see issue TBD. Untested since it got pulled in
+# TODO Experiment with this separately — see issue #593. Untested since it got pulled in
 # alongside CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP (which turned out to break light sleep
 # entirely with BLE active, see sdkconfig.carrot.defaults) and we haven't isolated its
 # own effect yet.

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -58,10 +58,19 @@ CONFIG_PM_RTOS_IDLE_OPT=y
 
 # Power down stuff
 CONFIG_PM_SLP_DISABLE_GPIO=y
+CONFIG_ESP_SLEEP_POWER_DOWN_FLASH=y
 CONFIG_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP=y
 CONFIG_PM_RESTORE_CACHE_TAGMEM_AFTER_LIGHT_SLEEP=y
-# TODO Experiment with this
+# TODO Experiment with this separately — see issue TBD. Untested since it got pulled in
+# alongside CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP (which turned out to break light sleep
+# entirely with BLE active, see sdkconfig.carrot.defaults) and we haven't isolated its
+# own effect yet.
 # CONFIG_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP=y
+
+# Enable DFS auto-init at startup. Harmless either way for us — PowerManager already
+# calls esp_pm_configure() explicitly at boot regardless of this setting — but avoids
+# briefly running at default (non-DFS) power settings before that call happens.
+CONFIG_PM_DFS_INIT_AUTO=y
 
 # Wi-Fi power saving options
 
@@ -152,37 +161,40 @@ CONFIG_BT_NIMBLE_SVC_DIS_MANUFACTURER_NAME=y
 CONFIG_BT_NIMBLE_SVC_DIS_FIRMWARE_REVISION=y
 CONFIG_BT_NIMBLE_SVC_DIS_SERIAL_NUMBER=y
 
+# Extended advertising (ble_gap_ext_adv_* in BleDriver::startAdvertising) instead of legacy
+# (ble_gap_adv_*) — matches Espressif's power_save reference example, which uses this by
+# default on ESP32-C6. A single extended AD payload fits everything (flags, name, all
+# service UUIDs) without needing a separate scan response.
+CONFIG_BT_NIMBLE_EXT_ADV=y
+
 # Wi-Fi + BLE coexistence
 CONFIG_ESP_COEX_SW_COEXIST_ENABLE=y
 # Power management for Wi-Fi + BLE coexistence
 CONFIG_ESP_COEX_POWER_MANAGEMENT=y
 
+# We only ever act as a BLE peripheral (advertising DIS, future Wi-Fi provisioning) —
+# never scan for or connect to other BLE devices. Dropping Central/Observer also
+# rules out any background scanning as a contributor to the light-sleep wakeup
+# storm under investigation (see PowerManager's diagnostic dump loop).
+# NOTE: if devices later need to talk to BLE peripherals of their own (e.g. soil
+# sensors), CENTRAL must be re-enabled — without it we can advertise but not
+# initiate connections or scan.
+CONFIG_BT_NIMBLE_ROLE_CENTRAL=n
+CONFIG_BT_NIMBLE_ROLE_OBSERVER=n
+
 # --- Optional NimBLE size-reduction knobs (review before enabling) -------------
 # Default NimBLE config compiles in all four roles, BLE5 features, and supports
 # up to 3 simultaneous connections — together this is ~235 KB in libble_app.a.
-# As of now we only use BLE as a *peripheral* (advertising DIS, future Wi-Fi
-# provisioning). If devices later need to scan or connect to BLE peripherals
-# of their own (e.g. soil sensors), they must keep the CENTRAL role enabled
-# — disabling CENTRAL means we can advertise but cannot initiate connections.
 #
 # Estimated savings (combined ~60–100 KB in libble_app.a; verify with `idf.py size`):
-#
-# # Drop the Central role (no outgoing connections, no scanning for connectable peers).
-# # Required if we later want to talk to BLE soil sensors as a client.
-# # CONFIG_BT_NIMBLE_ROLE_CENTRAL=n
-#
-# # Drop the Observer role (no passive scanning for beacons / advertisements).
-# # CONFIG_BT_NIMBLE_ROLE_OBSERVER=n
 #
 # # Cap simultaneous connections at 1 — we only ever talk to one phone/provisioner.
 # # Each extra slot costs ~1–2 KB RAM + some flash.
 # # CONFIG_BT_NIMBLE_MAX_CONNECTIONS=1
 #
-# # Disable BLE 5.0 extended/periodic advertising and 2M/Coded PHY. Phones do
-# # provisioning over legacy 1M PHY; we don't need extended adv for DIS.
-# # CONFIG_BT_NIMBLE_EXT_ADV=n
+# # Disable periodic advertising (we don't use it; separate from CONFIG_BT_NIMBLE_EXT_ADV,
+# # which we do use — see above).
 # # CONFIG_BT_NIMBLE_PERIODIC_ADV=n
-# # CONFIG_BT_NIMBLE_50_FEATURE_SUPPORT=n
 #
 # # Disable L2CAP connection-oriented channels (we only use ATT/GATT).
 # # CONFIG_BT_NIMBLE_L2CAP_COC_MAX_NUM=0

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -152,6 +152,11 @@ CONFIG_BT_NIMBLE_SVC_DIS_MANUFACTURER_NAME=y
 CONFIG_BT_NIMBLE_SVC_DIS_FIRMWARE_REVISION=y
 CONFIG_BT_NIMBLE_SVC_DIS_SERIAL_NUMBER=y
 
+# Wi-Fi + BLE coexistence
+CONFIG_ESP_COEX_SW_COEXIST_ENABLE=y
+# Power management for Wi-Fi + BLE coexistence
+CONFIG_ESP_COEX_POWER_MANAGEMENT=y
+
 # --- Optional NimBLE size-reduction knobs (review before enabling) -------------
 # Default NimBLE config compiles in all four roles, BLE5 features, and supports
 # up to 3 simultaneous connections — together this is ~235 KB in libble_app.a.

--- a/sdkconfig.pm_diagnostics.defaults
+++ b/sdkconfig.pm_diagnostics.defaults
@@ -1,0 +1,16 @@
+# Power-management diagnostics build (UD_PM_DIAGNOSTICS=1). Adds the instrumentation used to
+# root-cause the BLE/light-sleep wakeup storm fixed by disabling CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP
+# (see sdkconfig.carrot.defaults). Not for production: real, measurable overhead (the dump task
+# alone was ~9% CPU time in testing).
+
+# Cumulative held-time tracking (not just point-in-time active/inactive) for esp_pm_dump_locks —
+# needed because a lock acquired/released very briefly within a single dump interval would be
+# missed by a point-in-time snapshot alone.
+CONFIG_PM_PROFILING=y
+
+# Named period/count/exec-time stats in esp_timer_dump()
+CONFIG_ESP_TIMER_PROFILING=y
+
+# Per-task CPU time via vTaskGetRunTimeStats() (auto-selects FREERTOS_USE_TRACE_FACILITY +
+# FREERTOS_USE_STATS_FORMATTING_FUNCTIONS)
+CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y

--- a/sdkconfig.spinach.defaults
+++ b/sdkconfig.spinach.defaults
@@ -4,12 +4,17 @@
 CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
 
 #
-# BLE controller modem sleep — allows light sleep between advertising events (S3/C3 config names)
-# Main XTAL as LP clock: supports DFS + light sleep without an external 32kHz crystal.
+# Bluetooth — not supported on Spinach (pre-MK10 devices). See docs/specs/Bluetooth.md
+# ("Platform support decision") for the rationale: proper BLE support matters for new
+# (Carrot/MK10+) devices; older devices keep WiFi-only data transfer plus SoftAP/USB
+# provisioning, so it's not worth carrying ESP32-S3's BLE controller quirks (it shares
+# its BLE controller lineage with the older C3, not the newer C6/H2 stack). Disabling
+# CONFIG_BT_ENABLED here overrides sdkconfig.defaults' CONFIG_BT_ENABLED=y for this
+# platform only, and cascades to disable all dependent CONFIG_BT_NIMBLE_* options.
+# Code under `#ifdef CONFIG_BT_NIMBLE_ENABLED` (see BleDriver.hpp, Device.hpp) is
+# compiled out entirely on this platform.
 #
-CONFIG_BT_CTRL_MODEM_SLEEP=y
-CONFIG_BT_CTRL_MODEM_SLEEP_MODE_1=y
-CONFIG_BT_CTRL_LPCLK_SEL_MAIN_XTAL=y
+CONFIG_BT_ENABLED=n
 
 #
 # ULP coprocessor (used for pulse counting during light sleep)


### PR DESCRIPTION
## Summary

Enabling BLE (`DeviceSettings.bleEnabled`) on MK11 (ESP32-C6) originally pushed
average current from ~3 mA to ~13 mA. Root-caused two independent issues, fixed
a crash introduced while fixing the second, and made the result configurable.
Full writeup in `docs/specs/Bluetooth.md` ("WiFi/BLE Coexistence & Power"),
including the dead ends we ruled out along the way.

- **32.768 kHz crystal + coexistence PM** (MK11+): switch `RTC_CLK_SRC` to the
  external crystal on GPIO0/1 so `BT_LE_LP_CLK_SRC_DEFAULT` can be used within
  BLE-spec 500 PPM accuracy instead of keeping the main XTAL powered through
  light sleep; enable `ESP_COEX_SW_COEXIST_ENABLE`/`ESP_COEX_POWER_MANAGEMENT`
  so WiFi and BLE's sleep windows are coordinated. Fixes #576.
- **Root cause 1 — `CONFIG_ESP_WIFI_ENHANCED_LIGHT_SLEEP`**: silently made
  `esp_light_sleep_start()` reject 100% of attempts once BLE was active, even
  with WiFi never connected — its hardware beacon-wakeup registration collides
  with BT's own RTC/PMU wakeup source. Fix: keep it disabled (see the detailed
  comment in `sdkconfig.carrot.defaults`). ~33 mA -> ~4 mA.
- **Root cause 2 — coexistence scheduler keyed on BLE's advertising *state*,
  not actual on-air cadence**: continuous advertising (even at a slow 2 s
  interval) keeps the coex scheduler engaged and the chip waking from light
  sleep every ~2.8 ms. Fix: burst-mode advertising — single-event bursts,
  controller idle between them, restarted via a `ble_npl_callout`. Net
  over-the-air behavior unchanged (~2 s between connectable events).
  ~13 mA -> ~3-3.25 mA.
- **Crash fix**: the first burst-mode implementation reconfigured the
  advertising set (a real HCI round-trip) on every burst, which crashed the
  NimBLE host under real WiFi+MQTT+TLS load (NPL/HCI event pool exhaustion).
  Fixed by configuring once and only calling `ble_gap_ext_adv_start()` per
  burst, plus headroom (`CONFIG_BT_NIMBLE_TRANSPORT_EVT_COUNT` 30->60).
- Switched to BLE 5.0 extended advertising (bigger single AD payload, no
  separate scan response) — note nRF Connect doesn't show the device name
  with extended advertising, LightBlue and the companion app do; see the
  compatibility note in the doc.
- `DeviceSettings.bleAdvInterval` makes the burst interval configurable
  (default 2000 ms) instead of a hardcoded constant.
- Optional `UD_PM_DIAGNOSTICS=1` build flag (mirrors `UD_DEBUG`) adds the
  PM-lock/timer/wakeup-cause instrumentation used to find all of this, off by
  default (real overhead, ~9% CPU when on).
- BLE initialization errors (NimBLE init, GATT service registration, GAP/DIS
  setters) now throw instead of logging and continuing.
- **Disable BLE entirely on Spinach (pre-MK10 devices, ESP32-S3)**: proper BLE
  support (provisioning, local-only mode) only matters for new Carrot/MK10+
  devices going forward; older devices keep WiFi/MQTT + SoftAP/USB and don't
  need BLE, so there's no reason to carry NimBLE (or debug its ESP32-S3
  controller quirks) there. `CONFIG_BT_ENABLED=n` in `sdkconfig.spinach.defaults`
  cascades to disable the whole NimBLE Kconfig tree, and application code
  (`BleDriver.hpp`, `Device.hpp`) gates on `CONFIG_BT_NIMBLE_ENABLED` so
  `NimBleDriver` and its headers are compiled out of the Spinach binary
  entirely — confirmed no `NimBleDriver` symbols in the built ELF. Decision,
  rationale, and the legacy-advertising alternative that would justify
  revisiting this are documented in `docs/specs/Bluetooth.md` ("Platform
  support decision").

## Test plan

- [x] Build `carrot` (ESP32-C6), release and `UD_PM_DIAGNOSTICS=1`.
- [x] Build `spinach` (ESP32-S3) — now disables BLE entirely; confirmed clean
      build and no `NimBleDriver` symbols in the resulting binary.
- [x] Flash MK11 hardware; confirm BLE advertising/DIS/provisioning still
      connects reliably from a phone (LightBlue or the companion app).
- [x] Soak test: boot -> WiFi connect -> MQTT/TLS handshake -> ≥30 min of
      advertising bursts, mixed with BLE connect/disconnect, no crash.
- [x] PPK2 current measurement, BLE on vs off, confirming ~3 mA.

## Follow-ups (not in this PR)

- #593 — isolate `CONFIG_PM_POWER_DOWN_PERIPHERAL_IN_LIGHT_SLEEP` on its own.
- File an upstream ESP-IDF issue for the `ESP_WIFI_ENHANCED_LIGHT_SLEEP` + BLE
  interaction once reproduced on a minimal example.
- `SLP_SAMPLE_BEACON_FEATURE` as an alternative to the disabled hardware
  beacon-wakeup option — unexplored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H72rsp8Z4MTQ56vSKNQavU