### PR TITLE
Use the right variant of Spadefoot Toad connection with MK11

### DIFF
--- a/config-templates/plot-controller-mk11-spadefoot-toad.json
+++ b/config-templates/plot-controller-mk11-spadefoot-toad.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "soil",
-      "type": "soil:spadefoot-toad-bb",
+      "type": "soil:spadefoot-toad",
       "params": {
         "sda": "EXT_SDA",
         "scl": "EXT_SCL"


### PR DESCRIPTION
We don't need the bitbang anymore with MK11. It was a one-time fix for MK10.