### PR TITLE
Reduce Configuration/Property to parse-and-validate

### DIFF
--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -372,8 +372,10 @@ static void startDevice() {
         LOGTV(NVS, " - %s", key.c_str());
     });
 
-    auto networkConfig = loadConfigFromNvs<NetworkConfig>(configNvs, "network-config");
-    auto settings = loadConfigFromNvs<DeviceSettings>(configNvs, "device-config");
+    JsonDocument networkConfigRaw;
+    auto networkConfig = loadConfigFromNvs<NetworkConfig>(configNvs, "network-config", networkConfigRaw);
+    JsonDocument settingsRaw;
+    auto settings = loadConfigFromNvs<DeviceSettings>(configNvs, "device-config", settingsRaw);
 
     const std::string modelWithRevision = deviceDefinition->model + " (rev" + std::to_string(deviceDefinition->revision) + ")";
 
@@ -598,7 +600,7 @@ static void startDevice() {
 
     mqttRoot->publish(
         "init",
-        [resetReason, settings, macAddress, networkConfig, initState, peripheralsInitJson, functionsInitJson, powerManager, deviceDefinition, hardwareVersion](JsonObject& json) {
+        [resetReason, settingsRaw, macAddress, networkConfig, initState, peripheralsInitJson, functionsInitJson, powerManager, deviceDefinition, hardwareVersion](JsonObject& json) {
             json["model"] = deviceDefinition->model;
             json["revision"] = deviceDefinition->revision;
             json["platform"] = UD_PLATFORM;
@@ -608,8 +610,11 @@ static void startDevice() {
                 json["batch"] = hardwareVersion->batch;
                 json["serial"] = hardwareVersion->serial;
             }
+            // Echo the verbatim device-config body received/persisted at boot
             auto device = json["settings"].to<JsonObject>();
-            settings->store(device);
+            if (!settingsRaw.isNull()) {
+                device.set(settingsRaw.as<JsonObjectConst>());
+            }
             json["version"] = firmwareVersion;
 #ifdef UD_DEBUG
             json["debug"] = true;

--- a/components/functions/src/functions/Function.hpp
+++ b/components/functions/src/functions/Function.hpp
@@ -73,14 +73,19 @@ FunctionFactory makeFunctionFactory(
 
             constexpr bool hasConfig = std::is_base_of_v<HasConfig<TConfig>, Impl>;
 
-            // We load configuration up front to ensure that we always store it in the init message, even
+            // We load configuration up front to ensure that we always echo it in the init message, even
             // when the instantiation of the function fails later.
-            auto config = std::make_shared<TConfig>();
+            std::shared_ptr<TConfig> config;
             std::shared_ptr<NvsConfiguration<TConfig>> nvsConfig;
             if constexpr (hasConfig) {
-                nvsConfig = std::make_shared<NvsConfiguration<TConfig>>(nvs, params.name, config);
-                // Store configuration in init message
-                config->store(initConfigJson);
+                nvsConfig = std::make_shared<NvsConfiguration<TConfig>>(nvs, params.name);
+                config = nvsConfig->getConfig();
+                // Echo the verbatim config body in the init message
+                if (!nvsConfig->getRawJson().isNull()) {
+                    initConfigJson.set(nvsConfig->getRawJson().template as<JsonObjectConst>());
+                }
+            } else {
+                config = std::make_shared<TConfig>();
             }
 
             // Create concrete implementation via user-provided callable

--- a/components/kernel/src/Configuration.hpp
+++ b/components/kernel/src/Configuration.hpp
@@ -71,8 +71,6 @@ public:
     }
 
     virtual void load(const JsonObject& json) = 0;
-    virtual void reset() = 0;
-    virtual void store(JsonObject& json) const = 0;
     virtual bool hasValue() const = 0;
 };
 
@@ -86,18 +84,6 @@ public:
     void load(const JsonObject& json) override {
         for (auto& entry : entries) {
             entry.get().load(json);
-        }
-    }
-
-    void reset() override {
-        for (auto& entry : entries) {
-            entry.get().reset();
-        }
-    }
-
-    void store(JsonObject& json) const override {
-        for (const auto& entry : entries) {
-            entry.get().store(json);
         }
     }
 
@@ -143,25 +129,11 @@ public:
         if (json[name].template is<JsonObject>()) {
             namePresentAtLoad = true;
             delegate->load(json[name]);
-        } else {
-            reset();
-        }
-    }
-
-    void store(JsonObject& json) const override {
-        if (hasValue()) {
-            auto section = json[name].template to<JsonObject>();
-            delegate->store(section);
         }
     }
 
     bool hasValue() const override {
         return namePresentAtLoad || delegate->hasValue();
-    }
-
-    void reset() override {
-        namePresentAtLoad = false;
-        delegate->reset();
     }
 
     std::shared_ptr<TDelegateEntry> get() const {
@@ -177,9 +149,8 @@ private:
 template <typename T>
 class Property : public ConfigurationEntry {
 public:
-    Property(ConfigurationSection* parent, const std::string& name, const T& defaultValue = T(), const bool secret = false)
+    Property(ConfigurationSection* parent, const std::string& name, const T& defaultValue = T())
         : name(name)
-        , secret(secret)
         , value(defaultValue)
         , defaultValue(defaultValue) {
         parent->add(*this);
@@ -204,8 +175,6 @@ public:
         if (json[name].template is<T>()) {
             value = json[name].template as<T>();
             configured = true;
-        } else {
-            reset();
         }
     }
 
@@ -213,25 +182,8 @@ public:
         return configured;
     }
 
-    void reset() override {
-        configured = false;
-        value = T();
-    }
-
-    void store(JsonObject& json) const override {
-        if (!configured) {
-            return;
-        }
-        if (secret) {
-            json[name] = "********";
-        } else {
-            json[name] = get();
-        }
-    }
-
 private:
     const std::string name;
-    const bool secret;
     bool configured = false;
     T value;
     const T defaultValue;
@@ -250,7 +202,6 @@ public:
     }
 
     void load(const JsonObject& json) override {
-        reset();
         if (json[name].template is<JsonArray>()) {
             auto jsonArray = json[name].template as<JsonArray>();
             for (auto jsonEntry : jsonArray) {
@@ -262,17 +213,6 @@ public:
 
     bool hasValue() const override {
         return !entries.empty();
-    }
-
-    void reset() override {
-        entries.clear();
-    }
-
-    void store(JsonObject& json) const override {
-        auto jsonArray = json[name].template to<JsonArray>();
-        for (auto& entry : entries) {
-            jsonArray.add(entry);
-        }
     }
 
 private:

--- a/components/kernel/src/Manager.hpp
+++ b/components/kernel/src/Manager.hpp
@@ -205,7 +205,12 @@ public:
         const auto& name = settings->name.get();
         initJson["name"] = name;
         initJson["type"] = settings->type.get();
-        settings->params.store(initJson);
+        if (settings->params.hasValue()) {
+            // Echo the verbatim params body in the init message
+            JsonDocument paramsDoc;
+            deserializeJson(paramsDoc, settings->params.get().get());
+            initJson["params"].set(paramsDoc.as<JsonObjectConst>());
+        }
         try {
             this->createWithFactory(name, settings->type.get(), [&](const FactoryT& factory) {
                 initJson["factory"] = factory.factoryType;

--- a/components/kernel/src/NvsConfiguration.hpp
+++ b/components/kernel/src/NvsConfiguration.hpp
@@ -12,25 +12,33 @@ namespace cornucopia::ugly_duckling::kernel {
 
 /**
  * @brief Loads a ConfigurationSection from NVS, and persists updates back to NVS.
+ *
+ * Parsing always yields a fresh, immutable snapshot: the constructor and update() each
+ * build a new TConfiguration rather than mutating one in place. The raw JSON body behind
+ * the current snapshot is retained verbatim (getRawJson()) so callers can echo it back
+ * without re-serializing through the Configuration/Property tree.
  */
 template <std::derived_from<ConfigurationSection> TConfiguration>
 class NvsConfiguration {
 public:
-    NvsConfiguration(std::shared_ptr<NvsStore> nvs, const std::string& key, std::shared_ptr<TConfiguration> config)
+    NvsConfiguration(std::shared_ptr<NvsStore> nvs, const std::string& key)
         : nvs(std::move(nvs))
-        , key(key)
-        , config(std::move(config)) {
-        JsonDocument doc;
-        if (this->nvs->getJson(key, doc)) {
-            this->config->load(doc.as<JsonObject>());
+        , key(key) {
+        auto initial = std::make_shared<TConfiguration>();
+        if (this->nvs->getJson(key, raw)) {
+            initial->load(raw.as<JsonObject>());
             LOGD("Loaded NVS config for '%s'", key.c_str());
         } else {
             LOGD("No NVS config found for '%s', using defaults", key.c_str());
         }
+        config = initial;
     }
 
     void update(const JsonObject& json) {
-        config->load(json);
+        auto updated = std::make_shared<TConfiguration>();
+        updated->load(json);
+        config = updated;
+        raw.set(json);
         if (!nvs->setJson(key, json)) {
             LOGE("Failed to save NVS config for '%s'", key.c_str());
         }
@@ -40,26 +48,28 @@ public:
         return config;
     }
 
-    void store(JsonObject& json) const {
-        config->store(json);
+    const JsonDocument& getRawJson() const {
+        return raw;
     }
 
 private:
     std::shared_ptr<NvsStore> nvs;
     const std::string key;
+    JsonDocument raw;
     std::shared_ptr<TConfiguration> config;
 };
 
 /**
  * @brief Loads a ConfigurationSection from NVS by key.
  * Returns default-constructed config if key is absent or cannot be parsed.
+ * rawJson is populated with the verbatim JSON body that was parsed, or left null if the
+ * key was absent, so callers can echo it back without re-serializing through Configuration.
  */
 template <std::derived_from<ConfigurationSection> TConfiguration, typename... TArgs>
-std::shared_ptr<TConfiguration> loadConfigFromNvs(const std::shared_ptr<NvsStore>& nvs, const std::string& key, TArgs&&... args) {
+std::shared_ptr<TConfiguration> loadConfigFromNvs(const std::shared_ptr<NvsStore>& nvs, const std::string& key, JsonDocument& rawJson, TArgs&&... args) {
     auto config = std::make_shared<TConfiguration>(std::forward<TArgs>(args)...);
-    JsonDocument doc;
-    if (nvs->getJson(key, doc)) {
-        config->load(doc.as<JsonObject>());
+    if (nvs->getJson(key, rawJson)) {
+        config->load(rawJson.as<JsonObject>());
         LOGD("Loaded NVS config for '%s'", key.c_str());
     } else {
         LOGD("No NVS config found for '%s', using defaults", key.c_str());

--- a/components/kernel/test/ConfigurationTest.cpp
+++ b/components/kernel/test/ConfigurationTest.cpp
@@ -23,18 +23,8 @@ struct TestConfig : ConfigurationSection {
     NamedConfigurationEntry<TestNestedConfig> nested { this, "nested" };
 };
 
-std::string toString(const ConfigurationEntry& config) {
-    JsonDocument json;
-    auto root = json.to<JsonObject>();
-    config.store(root);
-    std::string jsonString;
-    serializeJson(json, jsonString);
-    return jsonString;
-}
-
-TEST_CASE("empty configuration is stored as empty JSON") {
+TEST_CASE("empty configuration has defaults and no values") {
     TestConfig config;
-    REQUIRE(toString(config) == R"({})");
     REQUIRE(!config.intValue.hasValue());
     REQUIRE(config.intValue.get() == 0);
     REQUIRE(!config.stringValue.hasValue());
@@ -96,7 +86,7 @@ TEST_CASE("configuration can be loaded from JSON with invalid values") {
     REQUIRE(config.nested.get()->intValue.get() == 0);
 }
 
-TEST_CASE("configuration with values is loaded from JSON and is stored as JSON") {
+TEST_CASE("configuration with values is loaded from JSON") {
     TestConfig config;
     config.loadFromString(R"({"intValue":42,"stringValue":"hello","boolValue":true,"secondsValue":60,"nested":{"intValue":7}})");
     REQUIRE(config.intValue.hasValue());
@@ -110,7 +100,6 @@ TEST_CASE("configuration with values is loaded from JSON and is stored as JSON")
     REQUIRE(config.nested.hasValue());
     REQUIRE(config.nested.get()->intValue.hasValue());
     REQUIRE(config.nested.get()->intValue.get() == 7);
-    REQUIRE(toString(config) == R"({"intValue":42,"stringValue":"hello","boolValue":true,"secondsValue":60,"nested":{"intValue":7}})");
 }
 
 struct TestNestedConfigWithDefaults : ConfigurationSection {
@@ -127,7 +116,6 @@ struct TestConfigWithDefaults : public ConfigurationSection {
 
 TEST_CASE("configuration with default values loaded from empty JSON has default values") {
     TestConfigWithDefaults config;
-    REQUIRE(toString(config) == R"({})");
     REQUIRE(!config.intValue.hasValue());
     REQUIRE(config.intValue.get() == 42);
     REQUIRE(!config.stringValue.hasValue());
@@ -144,7 +132,6 @@ TEST_CASE("configuration with default values loaded from empty JSON has default 
 TEST_CASE("configuration with default values loaded from non-empty JSON has actual values") {
     TestConfigWithDefaults config;
     config.loadFromString(R"({"intValue": 100, "stringValue": "custom", "boolValue": false, "secondsValue": 45, "nested": {"intValue": 200}})");
-    REQUIRE(toString(config) == R"({"intValue":100,"stringValue":"custom","boolValue":false,"secondsValue":45,"nested":{"intValue":200}})");
     REQUIRE(config.intValue.hasValue());
     REQUIRE(config.intValue.get() == 100);
     REQUIRE(config.stringValue.hasValue());

--- a/docs/specs/config-reconciliation.md
+++ b/docs/specs/config-reconciliation.md
@@ -330,9 +330,24 @@ device-configuration *authority transfer* land in Phase 3.
       is the only config-in path.
 - [ ] **No atomicity, no rejection.** A boot/apply failure is unrecoverable exactly as today; `rejected` is not
       emitted. (Deferred to Phase 3.)
-- [ ] **Tests.** Native: envelope round-trip, fingerprint-skip (including whole-message no-op), registry
-      manifest. e2e/embedded: drive an `UPDATE` (function-only and device-change), assert reboot vs hot-reload,
-      the `SYNC` manifest, and SYNC-gated-on-boot-success.
+- [ ] **Tests.** Split by tier — `NvsStore` talks to real `nvs.h` with no fake, so anything touching actual
+      NVS or a live MQTT connection cannot run in `unit-tests` (native); anything touching a live MQTT
+      connection cannot run in `embedded-tests` either (Wokwi without Mosquitto) — only `e2e-tests` has a
+      broker (see `CLAUDE.md`: "MQTT/WiFi behavior goes in `test/e2e-tests/`").
+    - **Native (`unit-tests`).** Requires `StoredConfig` to separate envelope JSON codec from NVS I/O (worth
+      doing regardless of tests). Envelope round-trip (serialize/parse only, no NVS); fingerprint-skip
+      filtering, including the whole-message no-op; `FunctionRegistry.manifest()`/`reconfigure()` against a
+      fake function handle.
+    - **Embedded (`embedded-tests`, Wokwi/IDF, no broker).** `StoredConfig` round-trip against real NVS;
+      boot loading `confirmed` from real NVS across a real device reset. (Slot swap / requested-vs-confirmed
+      boot selection for Phase 3 belongs here too — see below.)
+    - **e2e (`e2e-tests`, Wokwi + Mosquitto).** Everything that goes over the wire: drive an `UPDATE`
+      (function-only and device-change), assert reboot vs hot-reload, the `SYNC` manifest content, and
+      SYNC-gated-on-boot-success; same-fingerprint `UPDATE` is a no-op (assert absence of
+      reconfigure/reboot); the connection-established hook firing SYNC on connect/reconnect. **Blocked on
+      [#596](https://github.com/cornucopia-machines/ugly-duckling-firmware/issues/596)** — the e2e pytest
+      harness has no MQTT client today, only serial-output assertions, so none of this tier can be written
+      until that fixture exists.
 
 ### Phase 3 — atomicity, rejection, and device-config authority
 
@@ -353,6 +368,14 @@ device-configuration *authority transfer* land in Phase 3.
       `requested` and applied across a reboot.
 - [ ] **Retire the `nvs/write` + `restart` device-config path** once the server stops using it (keep raw
       `nvs/write` for debugging). Stop treating device-authored settings as ground truth.
+- [ ] **Tests.** The `config-state` transitions (`confirmed`/`requested{pending,attempted,rejected}` →
+      load/commit/revert) should be extracted as a pure function of state, not tested by physically crashing
+      a Wokwi device mid-write. **Native (`unit-tests`):** table-driven tests over that function for every
+      state combination, including "crashed while `attempted`". **Embedded (`embedded-tests`):** slot swap
+      and revert-to-`confirmed` against real NVS across a real reboot, seeding envelopes directly into NVS
+      rather than via `UPDATE` (no broker needed for this). **e2e (`e2e-tests`, blocked on
+      [#596](https://github.com/cornucopia-machines/ugly-duckling-firmware/issues/596)):** rejection code
+      reported on the `SYNC` following a revert, then cleared (report-once).
 
 ### Phase 4 — hardening (deferred)
 

--- a/docs/specs/config-reconciliation.md
+++ b/docs/specs/config-reconciliation.md
@@ -1,0 +1,363 @@
+# Config Reconciliation — firmware side (`BOOT`/`SYNC`/`UPDATE`, fingerprints, confirmed delivery)
+
+> Status: **Not started.** This is the firmware counterpart to the server-side spec in the app repo,
+> [`cornucopia-app/docs/specs/config-reconciliation.md`](../../../cornucopia-app/docs/specs/config-reconciliation.md).
+> **Read that spec first** — it owns the protocol design, the *why* behind every decision, and the
+> server/UX half. This document is the firmware implementation plan.
+>
+> **Prerequisite:** [`configuration-as-schema.md`](configuration-as-schema.md) — the `Configuration`/`Property`
+> teardown. This plan **assumes that refactor is already done**: configuration bodies are stored and echoed as
+> **verbatim JSON**, and persistence is separated from parsing. Land that first on its own branch, then build
+> this on top.
+>
+> The one-line summary of the firmware's job: **persist each configuration as `(data, fingerprint, requestedAt)`,
+> echo the fingerprints back in a `SYNC` manifest, apply configuration live (function-only change) or across a
+> reboot (device change), and report what is actually *running* — never compute a fingerprint, only parrot it.**
+
+## What the firmware is responsible for (and what it is not)
+
+The server is the **authority**. It decides what a device should run, holds `requested`/`confirmed` state,
+derives "pending", runs the retry/deadline policy, and owns the UX. The firmware's contract is deliberately
+dumb and stateless-by-comparison:
+
+- **Store what it is handed, verbatim.** Each `UPDATE` carries, per configuration, a body plus an opaque
+  `fingerprint` and a `requestedAt` timestamp. The firmware persists the three together and **never hashes
+  anything** — the fingerprint is a token it echoes, so a serialization mismatch can never cause an
+  apply-resend-apply livelock (server spec, *"The identity of a revision"*). Storing the body verbatim is what
+  makes this safe (see [`configuration-as-schema.md`](configuration-as-schema.md)).
+- **Skip what it already has.** If an `UPDATE` names a configuration whose `fingerprint` the device already
+  holds, that entry is a no-op. If **nothing** in an `UPDATE` differs, the whole message is ignored — no
+  re-apply, no reboot.
+- **Report what is running, not what is held.** `SYNC` is a manifest of the fingerprints of the configurations
+  the device has **applied and booted with** — proof-of-apply, not proof-of-receipt. It is built from the
+  **`confirmed`** configuration set (see *Storage*), and only sent **after a fully successful boot**.
+- **Keep running without the network.** The device applies its last-known-good (`confirmed`) configuration at
+  boot regardless of connectivity, and reconciles with the authority only when a connection exists. An
+  unreachable server never stalls the device.
+
+Everything about *when to retry*, *what "pending" means*, and *what the user sees* lives on the server.
+
+### New-protocol only — no dual stack, no legacy compatibility
+
+This firmware speaks **exactly one protocol: the new one.** There is no in-firmware compatibility with the old
+`init`-at-boot / retained-`config`-topic protocol, and we only ever talk to a server that speaks the new
+protocol end-to-end. This removes the "awkward hybrid" sequencing constraint the earlier draft worried about:
+the `BOOT`/`SYNC` split, the `UPDATE` channel, and device+function reconciliation all land **together**, in one
+self-consistent build. Coordinate the cutover so the server is on the new protocol before the first
+new-protocol device connects.
+
+## Naming: `settings` → `device configuration`
+
+As part of this work we **rename what the code currently calls (device) `settings` to "device configuration."**
+Today `DeviceSettings` ([`DeviceSettings.hpp`](../../components/devices/src/devices/DeviceSettings.hpp)) holds
+the `peripherals`/`functions` lists (which determine *which functions and peripherals exist*) plus device-wide
+tunables, loaded from the `device-config` key. Under reconciliation this is just **one more configuration
+document** — the `device` configuration — that carries a `fingerprint` like any other. The rename aligns the
+code with the protocol vocabulary (`device` vs. per-function configurations) and removes the "settings vs.
+config" ambiguity. This is tracked as its own checklist item because it touches type names, log strings, and
+the boot path broadly.
+
+## Where the firmware is today (grounding)
+
+Concrete anchors this plan builds on — verify these still hold before starting:
+
+- **`init` is published once per boot** in
+  [`Device.hpp` `startDevice()`](../../components/devices/src/Device.hpp). It carries device identity, the full
+  device configuration document, diagnostics (`reset`/`wakeup`/`bootCount`/`time`), an `InitState`, the full
+  per-peripheral/per-function init JSON (including `params`/`config`/`error`), and a crash report.
+  → This splits into **`BOOT`** (diagnostics + per-peripheral/function `error` feedback, **no configuration
+  bodies**) and **`SYNC`** (fingerprint manifest).
+
+- **Function configuration arrives on a retained topic and is applied live.**
+  [`Function.hpp` `makeFunctionFactory`](../../components/functions/src/functions/Function.hpp) subscribes each
+  function to `functions/<name>/config`; on a message it persists then calls `configure(...)`. This retained
+  subscription is **removed**; `UPDATE` becomes the only config-in path. The live `configure(...)` call is the
+  exact hot-reload path `UPDATE` reuses.
+
+- **Config is persisted as a bare body in NVS**, and `NvsConfiguration` couples parse and persist — both
+  addressed by the [`configuration-as-schema.md`](configuration-as-schema.md) prerequisite and the new
+  per-configuration store below.
+
+- **Device configuration** is loaded at boot from `device-config`; function configuration lives per-function in
+  the `function-cfg` namespace. **Network configuration** (`network-config`: MQTT broker, WiFi, instance) is
+  **separate and out of scope** — it is provisioned independently, must survive across everything here, and is
+  never part of the reconciled set.
+
+- **`FunctionManager`** ([`Function.hpp`](../../components/functions/src/functions/Function.hpp)) creates
+  functions from the device configuration's `functions` list and holds their handles. It becomes the
+  **`FunctionRegistry`** — the in-memory source of truth for `name → {live function, fingerprint}` (see below).
+
+- **MQTT topic model.** [`MqttRoot`](../../components/kernel/src/mqtt/MqttRoot.hpp) roots every device at
+  `…/devices/ugly-duckling/<instance>` and offers `publish`/`subscribe`/`clear`/`registerCommand`. `boot`,
+  `sync`, `update` sit **directly under the device root**, orthogonal to `commands`/`responses`.
+  `UPDATE`/`SYNC` deliberately do **not** reuse the command channel (server spec, *"`UPDATE` is not a
+  command"*).
+
+- **Connection lifecycle.** [`MqttDriver`](../../components/kernel/src/mqtt/MqttDriver.hpp) forces a **clean
+  session on every (re)connect** — the persistent-session path is disabled (`nextSessionShouldBeClean` stays
+  true; see the `TODO` around the `Connected` handler). There is **no application-level "connection
+  established" callback** today; the `SYNC` trigger needs one (see *SYNC*).
+  [`states->kernelReady`](../../components/kernel/src/KernelStatus.hpp) is set at the end of a successful boot
+  and is the "boot succeeded" signal the SYNC task gates on.
+
+- **Fingerprints are never computed on-device.** The device stores and echoes the server's token verbatim.
+
+## Storage: verbatim envelopes in swappable `confirmed`/`requested` namespaces
+
+### The per-configuration envelope
+
+Each configuration (the `device` document and each function) is stored as one **verbatim envelope**:
+
+```jsonc
+{
+  "data": { /* the configuration body, byte-for-byte as the server sent it */ },
+  "fingerprint": "…hex…",                // opaque token from the authority; never recomputed
+  "requestedAt": "2026-07-30T12:34:56Z"  // authored-at stamp, echoed back; encoded exactly like a
+                                         // plot-controller schedule `start` (ISO 8601 string), not interpreted
+}
+```
+
+A small **per-configuration store wrapper** (`StoredConfig`) owns reading/writing one such envelope in NVS and
+exposing `data` (verbatim) + `fingerprint` + `requestedAt`. This is **separate from parsing** — it never
+constructs a `Configuration`; parsing the `data` into a typed snapshot is a distinct step
+([`configuration-as-schema.md`](configuration-as-schema.md)). `NvsConfiguration`'s old parse-and-persist
+coupling is retired in favor of this split. One `nvs_set_blob` per envelope keeps `data`/`fingerprint`/
+`requestedAt` inseparable (per-configuration atomicity).
+
+The **device configuration** is held at runtime by its own `StoredConfig` (loaded at boot from the `confirmed`
+slot). That in-memory object is the **source of truth for the `device` manifest entry's fingerprint and
+`requestedAt`** — the single-document analogue of `FunctionRegistry` (below), which is the source of truth for
+every function's fingerprint. The `SYNC` builder reads both, never re-deriving anything from NVS at publish
+time.
+
+Because no legitimate configuration body has top-level `data` or `fingerprint` keys, the envelope shape is
+unambiguous. There is **no legacy bare-body reader** — this build never reads the old format (see *Migration*).
+
+### Two config-set slots + a state pointer
+
+The reconciled set (the `device` envelope + one envelope per function, keyed by function name) lives in a
+**slot namespace**. There are two interchangeable slots — `a` and `b`, say — and a separate small
+**`config-state`** namespace that records:
+
+- `confirmed`: which slot (`a`/`b`) holds the last-known-good set. Always present after first provisioning.
+- `requested`: `{ slot, state }` for a new-but-unconfirmed set, or absent. `state ∈ { pending, attempted,
+  rejected }`.
+- `rejection`: an optional stored `google.rpc.Code` to report on the next `SYNC` (Phase 3+; see *Rejection*).
+
+Each slot namespace holds a **full** set (device + every function), so a slot is self-contained: a boot loads
+exactly one slot and never merges. Network configuration stays in its own stable namespace and is never
+swapped.
+
+> **Phase 1 note.** The `requested` slot + state machine below is the **atomicity mechanism** and lands in
+> Phase 3. In Phase 1 there is a single `confirmed` slot and no revert: an `UPDATE` writes through and (if
+> device config changed) reboots; a boot that then fails is unrecoverable **exactly as today**. The full
+> two-slot design is documented here as the end goal so the Phase 1 shape is chosen to grow into it.
+
+## How reconciliation works (end-goal design)
+
+### Receiving an `UPDATE`
+
+1. **Filter by fingerprint.** For each named configuration (`device` and/or functions), drop entries whose
+   `fingerprint` already matches the `confirmed` slot. **If nothing differs, ignore the `UPDATE` entirely.**
+2. **Stage into `requested`.** Take the free slot (the non-`confirmed` one), copy every unchanged configuration
+   from `confirmed`, and overwrite the changed ones with the new envelopes. Mark `requested = { slot, pending }`.
+3. **Apply:**
+   - **Device configuration changed → reboot.** Do not hot-reload; let the boot sequence apply the whole
+     `requested` set (peripherals ride inside the device document — a device change can restructure which
+     functions exist).
+   - **Only function configurations changed → hot-reload.** Mark `requested` `attempted`, then for each changed
+     function call `FunctionRegistry.reconfigure(name, envelope)` → `configure(...)`. On success of all, **commit**
+     (`requested` becomes `confirmed`, old `confirmed` dropped, `requested` cleared). On any failure, mark
+     `rejected` and **reboot** (boot reverts to `confirmed`).
+
+In **Phase 1**, steps 2–3 collapse: write the changed envelopes straight into the single `confirmed` slot; if
+the device document changed, reboot; otherwise hot-reload the changed functions. No `requested`, no revert.
+
+### Boot
+
+Read `config-state`, then:
+
+- **No `requested`** → load `confirmed`. Boot. If boot fails, there is no recourse — fail as today (best-effort
+  try to get logs out over MQTT, but be prepared that MQTT may also be unavailable).
+- **`requested` == `pending`** → mark `attempted`, load `requested`. On a detected failure → mark `rejected`
+  and reboot (next boot reverts). On full success → **commit** (`requested` → `confirmed`).
+- **`requested` == `attempted`** (we started applying but crashed before committing or gracefully rejecting) or
+  **`rejected`** → record the rejection for the next `SYNC`, load `confirmed`, drop `requested`.
+
+So a bad `requested` set costs one extra reboot and always lands back on the last-known-good `confirmed` set.
+This is the atomic-revert mechanism; it is **Phase 3**. Phase 1 has only the "no `requested` → load
+`confirmed`" branch.
+
+**Commit is a single pointer flip.** "Commit" means: flip `config-state.confirmed` to point at the slot that
+was `requested` — **one NVS write, and that write is the commit point.** Everything after it (dropping the old
+slot, clearing `requested`) is idempotent cleanup that the next boot can re-derive, so a crash mid-cleanup is
+harmless: a boot that finds `confirmed` already pointing at the former `requested` slot simply finishes the
+cleanup.
+
+**What counts as boot success vs. failure** differs by which set is loaded:
+
+- **Booting the `confirmed` set is best-effort.** A peripheral or function whose apply errors is *recorded*
+  (the `InitState`/`error` feedback that rides on `BOOT`, as today), but boot still completes, `kernelReady` is
+  set, and `SYNC` is sent. There is no recourse — the last-known-good set is all we have.
+- **Booting a `requested` set is strict.** *Any* peripheral/function apply error (or a crash before boot
+  completes, i.e. `requested` still `attempted`) is a **detected failure** → mark `rejected`, reboot, revert to
+  `confirmed`. Only an error-free boot of a `requested` set commits and lets `SYNC` fire.
+
+### `FunctionRegistry` — the in-memory source of truth
+
+`FunctionManager` becomes `FunctionRegistry`. It owns, per live function, `{ handle, fingerprint }`:
+
+- **Populated at boot** as each function is created from the loaded slot: the registry records the function's
+  fingerprint from its envelope once `configure(...)` **succeeds** (proof-of-apply, not proof-of-receipt).
+- **`reconfigure(name, envelope)`** — the hot-reload entry point `UPDATE` calls: persist the envelope, parse,
+  `configure(...)`, and on success update the stored fingerprint. This is the logic that lives today inside the
+  per-function `functions/<name>/config` subscription lambda; it **moves out of the factory into the
+  registry**, so there is one apply path shared by boot and `UPDATE`, and one place that knows every function's
+  current fingerprint.
+- **`manifest()`** — yields `name → fingerprint` for the `SYNC` builder, straight from in-memory state (never
+  re-reading NVS, so it reflects what actually applied).
+
+A configuration for a function **not defined in the (potentially updated) device configuration** is a
+**protocol violation**, treated with the same seriousness as a malformed body — the server should never send
+one. It is a faulty configuration → `INVALID_ARGUMENT` once rejection exists (Phase 3); before then it is
+simply unhandled, exactly like any other faulty configuration today. Note the check is against the *post-update*
+device configuration: an `UPDATE` that introduces a new function bundles the device-configuration change that
+defines it, which reboots and rebuilds the registry, so the function *is* defined by the time its config
+applies.
+
+### `SYNC`
+
+- **Trigger: any successful MQTT connection**, delivered through a **single-element overwrite queue** into a
+  dedicated SYNC task. Coalescing means a flurry of reconnects (or a post-`UPDATE` request) collapses to one
+  pending SYNC — no pile-up if the link is flaky. (Explicit rate-limiting/throttling beyond the overwrite queue
+  is deemed unnecessary for now.)
+- **Gate: only after a fully successful boot.** The SYNC task awaits `kernelReady` (all functions configured
+  successfully) before publishing. If MQTT connects early, SYNC waits. If boot is **unsuccessful** with a
+  `requested` set, the device reboots to revert and **never sends SYNC** for that failed attempt.
+- **There is no boot-time / `startDevice()` SYNC.** With nothing to sync against absent a connection, the
+  connect trigger is the only trigger; the connection-established hook covers first boot and every reconnect
+  uniformly.
+- **Payload:** `{ configurations: { device: {fingerprint, requestedAt}, <function>: {fingerprint, requestedAt},
+  … } }` built from the `confirmed` slot / registry. A stored `rejection` code (Phase 3+) is included, then
+  **cleared locally** so it is reported exactly once. `NoRetain, QoS 2`.
+
+The **connection-established hook** is new surface on `MqttDriver`: a registered callback (analogous to how
+commands are registered), fired from the `Connected` event. Because that event runs on the MQTT event-loop task
+and `publish()` enqueues onto that same task and waits, the callback **must not publish inline** — it only
+pushes to the overwrite queue; the separate SYNC task does the publish.
+
+### `BOOT`
+
+- Queued once at boot (diagnostics + per-peripheral/function `error` feedback; **no configuration bodies**),
+  delivered when MQTT connects. `NoRetain, QoS 1`.
+- If the device reboots due to a faulty `requested` configuration **before** MQTT is established, that `BOOT`
+  never reaches the server — accepted; the eventual `SYNC` after a successful boot (carrying the rejection
+  code) is what informs the server.
+
+### QoS 2 + clean session — an explicit assumption
+
+`update` is subscribed and `sync` published at **QoS 2**. The MQTT driver forces a **clean session on every
+reconnect**, so an `UPDATE` published while the device is offline is **not broker-queued** and is lost.
+**This is by design and fine:** delivery of `UPDATE` is never relied upon. The device's `SYNC` on the next
+successful connection re-advertises its `confirmed` fingerprints, and the server re-pushes whatever differs.
+Reconciliation converges through SYNC-driven re-push, not through MQTT delivery guarantees.
+
+### Rejection
+
+Rejection is a single `google.rpc.Code` on `SYNC` (`INVALID_ARGUMENT`=3, `FAILED_PRECONDITION`=9,
+`RESOURCE_EXHAUSTED`=8, `UNIMPLEMENTED`=12, `INTERNAL`=13; `OK`=0 is never sent — a matching fingerprint *is*
+success). No message travels on the wire; human-readable detail goes to the `log` channel and an operator
+correlates by device + time.
+
+**Rejection is Phase 3.** It only becomes meaningful once we can apply-or-reject an `UPDATE` **atomically** (the
+two-slot revert), and until then we **do not handle faulty configuration at all** — exactly as today. The code
+subset and the "store rejection across the revert reboot, report once in the next `SYNC`, then clear" flow are
+specified here so Phase 3 has a target, but nothing emits `rejected` before then.
+
+## Migration
+
+There is **no in-place NVS migration** and no reader for the old bare-body format. On the first boot of the new
+firmware the slot layout is effectively empty, so the device reconciles from the server: an empty (or minimal)
+`SYNC` prompts the server to re-push the full configuration set. Network configuration is untouched, so the
+device still connects.
+
+This means an upgraded device runs with **no device/function configuration** (defaults only) for the window
+between first boot and the server's re-push + reboot. **We accept this as a cost of keeping the design simple:**
+a firmware update already takes the device offline for a while (HTTP update requires connectivity and reboots),
+so a short additional reconfiguration round-trip is not a meaningful regression. No one-time import of the old
+`device-config`/`function-cfg` blobs is done.
+
+---
+
+## Progress checklist
+
+These phases are the firmware's own; they do **not** have to line up with the server spec's phase numbers.
+Because there is no legacy dual stack, the firmware's new-protocol surface (`BOOT`/`SYNC`/`UPDATE`,
+drop-retained, device+function reconciliation) lands as **one milestone** in Phase 1; atomicity + rejection +
+device-configuration *authority transfer* land in Phase 3.
+
+### Phase 0 — prerequisite
+
+- [ ] **`Configuration`/`Property` teardown** per [`configuration-as-schema.md`](configuration-as-schema.md):
+      verbatim-JSON storage, persistence split from parsing, `store()` removed once `BOOT` stops echoing config
+      bodies. **Do this first, on its own branch.**
+
+### Phase 1 — the new protocol, happy path (single `confirmed` slot, no atomicity)
+
+- [ ] **Rename `settings` → device `configuration`.** `DeviceSettings` and the `device-config` load path,
+      including type names and log strings. The `device` document becomes a reconciled configuration with a
+      fingerprint like any other.
+- [ ] **Per-configuration envelope + store.** Introduce the verbatim `{data, fingerprint, requestedAt}`
+      envelope and a `StoredConfig` wrapper (read/write one envelope, expose `data`/`fingerprint`/`requestedAt`),
+      separate from parsing. `requestedAt` is an ISO 8601 string (encoded like a schedule `start`).
+- [ ] **`FunctionRegistry`.** Evolve `FunctionManager` into the in-memory `name → {handle, fingerprint}` source
+      of truth. Move the hot-reload logic out of the per-function `config` subscription into
+      `reconfigure(name, envelope)`; record fingerprints on successful `configure(...)` at boot and on reload;
+      expose `manifest()`.
+- [ ] **`…/update` subscription + handler.** Subscribe the device root to `update` (`NoRetain, QoS 2`). Parse
+      `configurations`; filter by held fingerprints (ignore the whole message if nothing differs). Persist
+      changed envelopes to the (single) `confirmed` slot. **Device changed → reboot; functions-only changed →
+      hot-reload via `FunctionRegistry.reconfigure`.** A config for a function not defined by the (post-update)
+      device configuration is a faulty configuration (unhandled in Phase 1, exactly like a malformed body).
+- [ ] **Split `init` into `BOOT` + `SYNC`.** `boot` keeps all diagnostics + per-peripheral/function `error`
+      feedback and **drops all configuration bodies** (`NoRetain, QoS 1`). `sync` is the fingerprint manifest
+      from the `confirmed` slot / registry (`NoRetain, QoS 2`).
+- [ ] **Connection-established hook + SYNC task.** Add a registered on-connect callback to `MqttDriver` (fires
+      from the `Connected` event; must not publish inline). It pushes to a **single-element overwrite queue**; a
+      dedicated SYNC task takes from it, **awaits `kernelReady`**, then publishes `SYNC`. Also publish `SYNC`
+      immediately after a successful hot-reload `UPDATE` (via the same queue). No `SYNC` from `startDevice()`.
+- [ ] **Drop the retained `config` subscription.** Remove `functions/<name>/config` in `Function.hpp`; `UPDATE`
+      is the only config-in path.
+- [ ] **No atomicity, no rejection.** A boot/apply failure is unrecoverable exactly as today; `rejected` is not
+      emitted. (Deferred to Phase 3.)
+- [ ] **Tests.** Native: envelope round-trip, fingerprint-skip (including whole-message no-op), registry
+      manifest. e2e/embedded: drive an `UPDATE` (function-only and device-change), assert reboot vs hot-reload,
+      the `SYNC` manifest, and SYNC-gated-on-boot-success.
+
+### Phase 3 — atomicity, rejection, and device-config authority
+
+> The device-configuration **authority transfer** (server seeds device config at provisioning; retire
+> `nvs/write` as the write mechanism) depends on the server side + `ble-provisioning.md`. The **atomicity +
+> rejection** mechanism below is firmware-local and could land earlier if useful.
+
+- [ ] **Two-slot `confirmed`/`requested` + `config-state` machine.** Implement the staging/commit/revert flow:
+      stage changes into `requested`, mark `pending`→`attempted`, commit on success, revert to `confirmed` on
+      failure across a reboot. `config-state` records `confirmed`/`requested`/`rejection`.
+- [ ] **Boot-time apply detection + revert.** Detect a `requested` set that fails to boot (including a crash
+      that leaves it `attempted`) and revert to `confirmed`, recording the rejection.
+- [ ] **Rejection reporting.** Persist the `google.rpc.Code` across the revert reboot; include it in the next
+      `SYNC`, then clear it (report-once). Map parse/validation → `INVALID_ARGUMENT`, unknown function type →
+      `UNIMPLEMENTED`, NVS-full → `RESOURCE_EXHAUSTED`, else `INTERNAL`.
+- [ ] **`device` in the `SYNC` manifest + full `UPDATE` handling.** Report the `device` fingerprint; handle an
+      `UPDATE` that bundles the `device` document plus every function it defines, persisted atomically into
+      `requested` and applied across a reboot.
+- [ ] **Retire the `nvs/write` + `restart` device-config path** once the server stops using it (keep raw
+      `nvs/write` for debugging). Stop treating device-authored settings as ground truth.
+
+### Phase 4 — hardening (deferred)
+
+- [ ] **Known-good slot + boot-loop protection** for a configuration that *kills the device* before it can
+      report anything (a bad-payload boot loop — distinct from the serialization livelock the never-hash design
+      already rules out). A device-side watchdog around the first successful apply after an `UPDATE`.
+- [ ] **`requestedAt`/LWW** — the device already persists and echoes `requestedAt`; multi-writer
+      last-write-wins rules (BLE-direct writes) are designed in `device-protocol-v2.md`, not here.

--- a/docs/specs/configuration-as-schema.md
+++ b/docs/specs/configuration-as-schema.md
@@ -1,13 +1,14 @@
 # Configuration as schema — reduce `Configuration`/`Property` to parse-and-validate
 
-> Status: **Not started.** This is a **prerequisite refactor** for
-> [`config-reconciliation.md`](config-reconciliation.md): that plan assumes the model described here is
-> already in place (configuration bodies stored/echoed as verbatim JSON, persistence separated from parsing).
-> Land this first on its own branch, then return to the reconciliation work.
+> Status: **Done.** Landed together with the `store()` removal (see note at the end of the work outline):
+> `init`-message config echoing now uses verbatim JSON everywhere, so there was no reason to keep the
+> serialization machinery around as dead code in the meantime. [`config-reconciliation.md`](config-reconciliation.md)
+> can now build on this model (configuration bodies stored/echoed as verbatim JSON, persistence separated from
+> parsing).
 >
-> One-line summary: **`Configuration` should declare a schema, supply defaults, and parse+validate a JSON
-> object into an immutable typed value — nothing more. Persisting and printing configuration JSON moves out of
-> `Configuration` and is handled verbatim.**
+> One-line summary: **`Configuration` declares a schema, supplies defaults, and parses+validates a JSON object
+> into an immutable typed value — nothing more. Persisting and printing configuration JSON happens verbatim,
+> outside `Configuration`.**
 
 ## Why
 
@@ -77,33 +78,31 @@ to unblock reconciliation.
 
 ## Work outline
 
-Ordered for the branch. Most of the teardown lands independently; the **one** cross-spec dependency is the
-final removal of `store()`, whose last callers are the `init`-message population sites — those disappear when
-[`config-reconciliation.md`](config-reconciliation.md) Phase 1 splits `init` into `BOOT` (config bodies
-dropped). Sequence this branch so `store()` deletion is the hand-off point to the reconciliation work.
-
-- [ ] **Split parse from persist.** Separate "parse a `JsonObject` into a typed snapshot" (stays with
-      `Configuration`) from "persist the raw body" (moves out). Reduce/retire `NvsConfiguration`'s
-      parse-and-persist coupling; repoint the boot-time function/peripheral/device load paths so parsing takes a
-      `JsonObject` and persistence is a caller concern.
-- [ ] **Store the configuration body verbatim.** Persist and print the JSON exactly as received; stop
-      re-serializing from a `Configuration`. This is the behavior the fingerprint contract depends on.
-- [ ] **Snapshot semantics for `Property`/`ArrayProperty`/`NamedConfigurationEntry`.** Parsing yields a fresh
-      immutable snapshot; a re-configure parses a new `Configuration` rather than mutating one. Drop the
-      in-place-reload contract (`reset()`, mutate-on-`load`).
-- [ ] **Trim the mutable/optional accessor surface.** Audit `getIfPresent()`/`getOrDefault()`/`hasValue()`
-      callers; keep only what schema consumers genuinely need at parse time, drop the rest.
-- [ ] **Verbatim JSON for diagnostics.** Anywhere configuration was printed via `store()`, print the stored raw
-      JSON instead.
-- [ ] **Remove `store()` from the `Configuration` hierarchy** (`ConfigurationSection`, `Property`,
-      `ArrayProperty`, `NamedConfigurationEntry`). Gate on the `init`/`BOOT` split having dropped the last
-      callers ([`Device.hpp:612`](../../components/devices/src/Device.hpp),
-      [`Manager.hpp:208`](../../components/kernel/src/Manager.hpp),
-      [`Function.hpp:83`](../../components/functions/src/functions/Function.hpp),
-      [`NvsConfiguration.hpp:44`](../../components/kernel/src/NvsConfiguration.hpp)); this is the coordination
-      point with the reconciliation branch.
-- [ ] **Tests.** Keep/adjust `ConfigurationTest` for parse+defaults+validation; drop the
-      round-trip-serialization assertions (`ConfigurationTest.cpp:29`).
+- [x] **Split parse from persist.** `NvsConfiguration<TConfiguration>` and `loadConfigFromNvs` now construct a
+      fresh typed snapshot on every load, and expose the raw `JsonDocument` they parsed from (`getRawJson()` /
+      the out-param on `loadConfigFromNvs`) so callers can echo it verbatim instead of re-deriving it.
+- [x] **Store the configuration body verbatim.** `Device.hpp`, `Manager.hpp`, and `Function.hpp` now embed the
+      raw JSON retained from parsing directly into the `init` message instead of calling `store()`.
+- [x] **Snapshot semantics for `Property`/`ArrayProperty`/`NamedConfigurationEntry`.** `load()` no longer relies
+      on `reset()` — a fresh instance already starts in its default/unconfigured state, so absent JSON fields are
+      simply left alone. `NvsConfiguration::update()` builds a new snapshot and swaps the `shared_ptr` rather than
+      mutating the existing one in place.
+- [x] **Trim the mutable/optional accessor surface.** Audited `getIfPresent()`/`getOrDefault()`/`hasValue()` —
+      every one has a live caller (`ChickenDoor`/`PlotController` configure(), `UglyDucklingMk6Base`), so nothing
+      to drop. The unused `secret` masking parameter on `Property` (never passed `true` anywhere) was dropped
+      along with `store()`.
+- [x] **Verbatim JSON for diagnostics.** Covered by the same call-site changes as "store verbatim" above — there
+      were no other `store()`-based print sites.
+- [x] **Remove `store()` from the `Configuration` hierarchy** (`ConfigurationSection`, `Property`,
+      `ArrayProperty`, `NamedConfigurationEntry`, and the `NvsConfiguration` passthrough). This landed in the same
+      branch as the verbatim-echo changes above rather than being deferred to the reconciliation branch: once
+      `Device.hpp`/`Manager.hpp`/`Function.hpp` stopped calling it, `store()` had zero callers, and there was no
+      reason to leave dead serialization code in the tree waiting for a coordinated deletion. The `init` message's
+      wire shape (keys present, retention/QoS) is unchanged — only how the `settings`/`params`/`config` bodies are
+      produced (verbatim JSON instead of re-serialized from a `Configuration`) is different, matching the
+      non-goal below.
+- [x] **Tests.** `ConfigurationTest` keeps parse+defaults+validation coverage; the round-trip-serialization
+      assertions and the `toString()` helper were dropped.
 
 ## Non-goals
 

--- a/docs/specs/configuration-as-schema.md
+++ b/docs/specs/configuration-as-schema.md
@@ -1,0 +1,114 @@
+# Configuration as schema — reduce `Configuration`/`Property` to parse-and-validate
+
+> Status: **Not started.** This is a **prerequisite refactor** for
+> [`config-reconciliation.md`](config-reconciliation.md): that plan assumes the model described here is
+> already in place (configuration bodies stored/echoed as verbatim JSON, persistence separated from parsing).
+> Land this first on its own branch, then return to the reconciliation work.
+>
+> One-line summary: **`Configuration` should declare a schema, supply defaults, and parse+validate a JSON
+> object into an immutable typed value — nothing more. Persisting and printing configuration JSON moves out of
+> `Configuration` and is handled verbatim.**
+
+## Why
+
+`Configuration`/`Property` ([`Configuration.hpp`](../../components/kernel/src/Configuration.hpp)) were designed
+in the early days as **long-lived, mutable** objects: a `Property` holds a current value you can read at any
+time, `load()` mutates it in place, and the whole tree can serialize itself back to JSON via `store()`. That is
+no longer how the firmware uses them.
+
+Today we:
+
+- **Read a configuration once**, at initialization and again inside `HasConfig::configure()`, and we do **not**
+  retain references to `Property` objects afterwards. The "live, always-current value" semantics buy us nothing.
+- Only call `store()` to **echo configuration back into the `init` message** — and
+  [`config-reconciliation.md`](config-reconciliation.md) removes configuration bodies from that message
+  entirely (the new `BOOT` message carries diagnostics only). After that split, `store()` has **no production
+  callers left**.
+
+So `Configuration` carries mutable state and serialization machinery we don't need, and the reconciliation work
+wants the opposite contract: **store and print whatever JSON the server sent, verbatim**, and treat a parsed
+`Configuration` as a throw-away typed view over one snapshot. `Configuration` and `Property` are, frankly,
+overengineered remnants; the long-term intent is to remove them, but this refactor just dumbs them down enough
+to unblock reconciliation.
+
+## Where this bites today (grounding)
+
+- **`store()` (serialization) has only init-message callers**, all of which
+  [`config-reconciliation.md`](config-reconciliation.md) removes:
+  - [`Device.hpp:612`](../../components/devices/src/Device.hpp) — `settings->store(device)` (device
+    configuration into `init`).
+  - [`Manager.hpp:208`](../../components/kernel/src/Manager.hpp) — `settings->params.store(initJson)`
+    (peripheral/function params into `init`).
+  - [`Function.hpp:83`](../../components/functions/src/functions/Function.hpp) —
+    `config->store(initConfigJson)` (function config body into `init`).
+  - [`NvsConfiguration.hpp:44`](../../components/kernel/src/NvsConfiguration.hpp) — a thin `store()` pass-through.
+  - [`ConfigurationTest.cpp:29`](../../components/kernel/test/ConfigurationTest.cpp) — round-trip test.
+- **`NvsConfiguration` couples parse and persist**: its constructor reads NVS → `config->load(...)`, and
+  `update()` does `config->load(json)` **and** `nvs->setJson(key, json)` in one call. Reconciliation needs
+  these two responsibilities split (parse a snapshot vs. persist the raw envelope).
+- **Mutable `Property` state** (`value`/`configured`, `reset()`, `getIfPresent()`/`getOrDefault()`) exists to
+  support in-place reload. With snapshot semantics, a fresh `Configuration` is parsed per apply and discarded;
+  no in-place mutation is required.
+
+## Target model
+
+- **`Configuration` = schema + defaults + parse/validate → immutable typed value.**
+  - Keep the declaration surface: `ConfigurationSection`, `Property<T>`, `ArrayProperty<T>`,
+    `NamedConfigurationEntry<T>`, `HasConfig<TConfig>`, and the ArduinoJson `Converter`s (durations,
+    `JsonAsString`, `system_clock::time_point`, …). Schemas already written across peripherals/functions must
+    keep compiling with minimal churn.
+  - Parsing a JSON object yields a **snapshot**: values + defaults resolved once, then treated as immutable. A
+    re-configure parses a **new** `Configuration` rather than mutating an existing one.
+  - **Drop the serialization path** (`store()` on every entry type) once its init-message callers are gone.
+  - **Drop in-place mutation** semantics (`reset()`, the mutate-on-`load` contract). Whether `Property` keeps a
+    private `value` internally is an implementation detail; the point is nothing outside relies on it changing
+    after parse.
+  - Keep validation: a body that fails to parse/validate throws `ConfigurationException` (unchanged), which the
+    reconciliation apply path turns into a failure.
+- **Raw JSON is the source of truth for storage and diagnostics.** The configuration body is stored and echoed
+  **verbatim** (as the server sent it), never re-serialized from a `Configuration`. This is what makes the
+  fingerprint contract safe end-to-end: the device round-trips bytes it does not reinterpret. Diagnostics that
+  used to print `store()` output print the stored raw JSON instead.
+- **Persistence separates from parsing.** `NvsConfiguration`'s dual role is split:
+  - parsing/validation stays with `Configuration` (given a `JsonObject`, produce a typed snapshot);
+  - persistence moves to the reconciliation layer's per-configuration store (the envelope wrapper described in
+    [`config-reconciliation.md`](config-reconciliation.md)), which owns the raw `data` JSON plus its
+    `fingerprint`/`requestedAt`.
+
+## Work outline
+
+Ordered for the branch. Most of the teardown lands independently; the **one** cross-spec dependency is the
+final removal of `store()`, whose last callers are the `init`-message population sites — those disappear when
+[`config-reconciliation.md`](config-reconciliation.md) Phase 1 splits `init` into `BOOT` (config bodies
+dropped). Sequence this branch so `store()` deletion is the hand-off point to the reconciliation work.
+
+- [ ] **Split parse from persist.** Separate "parse a `JsonObject` into a typed snapshot" (stays with
+      `Configuration`) from "persist the raw body" (moves out). Reduce/retire `NvsConfiguration`'s
+      parse-and-persist coupling; repoint the boot-time function/peripheral/device load paths so parsing takes a
+      `JsonObject` and persistence is a caller concern.
+- [ ] **Store the configuration body verbatim.** Persist and print the JSON exactly as received; stop
+      re-serializing from a `Configuration`. This is the behavior the fingerprint contract depends on.
+- [ ] **Snapshot semantics for `Property`/`ArrayProperty`/`NamedConfigurationEntry`.** Parsing yields a fresh
+      immutable snapshot; a re-configure parses a new `Configuration` rather than mutating one. Drop the
+      in-place-reload contract (`reset()`, mutate-on-`load`).
+- [ ] **Trim the mutable/optional accessor surface.** Audit `getIfPresent()`/`getOrDefault()`/`hasValue()`
+      callers; keep only what schema consumers genuinely need at parse time, drop the rest.
+- [ ] **Verbatim JSON for diagnostics.** Anywhere configuration was printed via `store()`, print the stored raw
+      JSON instead.
+- [ ] **Remove `store()` from the `Configuration` hierarchy** (`ConfigurationSection`, `Property`,
+      `ArrayProperty`, `NamedConfigurationEntry`). Gate on the `init`/`BOOT` split having dropped the last
+      callers ([`Device.hpp:612`](../../components/devices/src/Device.hpp),
+      [`Manager.hpp:208`](../../components/kernel/src/Manager.hpp),
+      [`Function.hpp:83`](../../components/functions/src/functions/Function.hpp),
+      [`NvsConfiguration.hpp:44`](../../components/kernel/src/NvsConfiguration.hpp)); this is the coordination
+      point with the reconciliation branch.
+- [ ] **Tests.** Keep/adjust `ConfigurationTest` for parse+defaults+validation; drop the
+      round-trip-serialization assertions (`ConfigurationTest.cpp:29`).
+
+## Non-goals
+
+- **Deleting `Configuration`/`Property` outright.** That's the eventual direction, not this change. This spec
+  only removes the mutable/serialization machinery so reconciliation can treat configurations as throw-away
+  parsed snapshots over verbatim JSON.
+- **Any wire/protocol change.** This is an internal representation refactor; it ships independently and is
+  observable only as "the device no longer echoes config bodies via re-serialization."


### PR DESCRIPTION
## Summary
- Implements `docs/specs/configuration-as-schema.md`: `Configuration`/`Property` are reduced from long-lived mutable objects to parse-and-validate-only — parsing always yields a fresh immutable snapshot, `store()`/`reset()`/mutate-on-load are removed.
- `Device.hpp`, `Manager.hpp`, and `Function.hpp` now embed the verbatim JSON retained from parsing into the `init` message instead of re-serializing through `Configuration`/`Property`.
- `NvsConfiguration` exposes the raw parsed JSON (`getRawJson()`) so callers can echo it verbatim.
- Adds `docs/specs/configuration-as-schema.md` and `docs/specs/config-reconciliation.md` (the latter is the not-yet-started firmware plan this refactor unblocks; work continues on this branch).

## Target platform
Both `carrot` (ESP32-C6) and `spinach` (ESP32-S3) — no platform-specific code paths touched.

## Test plan
- [x] Native Catch2 suite (`test/unit-tests`): 267 assertions / 71 test cases pass, including updated `ConfigurationTest` coverage (parse/defaults/validation; round-trip-serialization and `toString()` assertions dropped along with `store()`).
- [x] `idf.py build` succeeds for both `carrot` and `spinach` build trees (per commit message; wire shape of `init` unchanged — only how `settings`/`params`/`config` bodies are produced differs).
- No NVS config schema changes; no wire/protocol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wmTrPK75nYzzWZUfwBnGh