### PR TITLE
Handle new HTTP client events in OTA update handler

### DIFF
--- a/components/kernel/src/HttpUpdate.hpp
+++ b/components/kernel/src/HttpUpdate.hpp
@@ -115,6 +115,12 @@ private:
             case HTTP_EVENT_ON_HEADER:
                 LOGTV(UPDATE, "HTTP header: %s: %s", event->header_key, event->header_value);
                 break;
+            case HTTP_EVENT_ON_HEADERS_COMPLETE:
+                LOGTV(UPDATE, "HTTP headers complete");
+                break;
+            case HTTP_EVENT_ON_STATUS_CODE:
+                LOGTV(UPDATE, "HTTP status code: %d", *reinterpret_cast<int*>(event->data));
+                break;
             case HTTP_EVENT_ON_DATA: {
                 LOGTD(UPDATE, "HTTP data: %d bytes", event->data_len);
                 // Keep running while we are receiving data


### PR DESCRIPTION
## Summary
- ESP-IDF v6.0.2 added `HTTP_EVENT_ON_HEADERS_COMPLETE` and `HTTP_EVENT_ON_STATUS_CODE` to `esp_http_client_event_id_t`, inserted between `HTTP_EVENT_ON_HEADER` and `HTTP_EVENT_ON_DATA`.
- `HttpUpdater::handleEvent` in `components/kernel/src/HttpUpdate.hpp` didn't have cases for them, so they fell into the `default` branch and logged spurious warnings (`Unknown HTTP event 4` / `Unknown HTTP event 5`) during every OTA download.
- Added explicit `LOGTV` cases for both, consistent with the other bookkeeping events in the same switch.

## Test plan
- [x] `idf.py -B build-carrot build` succeeds (`IDF_TARGET=esp32c6`)
- [x] Trigger an OTA update on hardware/Wokwi and confirm the warning no longer appears in the logs

Target platform: both `carrot` (esp32c6) and `spinach` (esp32s3) — the code is platform-agnostic (shared `kernel` component).