### PR TITLE
Handle provisioned configuration being rejected

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,13 +136,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Configure
+        run: cmake -G Ninja -DCMAKE_CXX_COMPILER=clang++ -S test/unit-tests -B test/unit-tests/build-native
+
       - name: Build Project
-        uses: threeal/cmake-action@v2.1.0
-        with:
-          generator: Ninja
-          cxx-compiler: clang++
-          source-dir: test/unit-tests
-          build-dir: test/unit-tests/build-native
+        run: cmake --build test/unit-tests/build-native
 
       - name: Run tests
         working-directory: test/unit-tests/build-native

--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -870,6 +870,8 @@ static void startDevice() {
         if (!success) {
             LOGE("Requested configuration failed to apply (state=%d); reverting and rebooting",
                 static_cast<int>(initState));
+            // Give the log a chance to flush before rebooting
+            Task::delay(5s);
             esp_restart();
             return;
         }


### PR DESCRIPTION
Wait a bit before rebooting so we can learn what happened to the device.