### PR TITLE
Investigate memory leak

### DIFF
--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -161,6 +161,15 @@ static void performFactoryReset(const std::shared_ptr<LedDriver>& statusLed, boo
     esp_restart();
 }
 
+// TODO(heap-investigation): temporary boot-time heap checkpoints, remove once the two-slot
+// config protocol's memory usage regression (docs/Configuration.md) is diagnosed.
+static void logHeapCheckpoint(const char* label) {
+    LOGI("Heap checkpoint '%s': free = %lu, min-free = %lu",
+        label,
+        static_cast<unsigned long>(heap_caps_get_free_size(MALLOC_CAP_INTERNAL)),
+        static_cast<unsigned long>(heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL)));
+}
+
 std::shared_ptr<BatteryDriver> initBattery(const std::shared_ptr<DeviceDefinition>& deviceDefinition, const std::shared_ptr<I2CManager>& i2c) {
     auto battery = deviceDefinition->createBatteryDriver(i2c);
     if (battery != nullptr) {
@@ -555,6 +564,7 @@ static void startDevice() {
     auto battery = initBattery(deviceDefinition, i2c);
 
     initNvsFlash();
+    logHeapCheckpoint("after nvs flash init");
 
     // Install GPIO ISR service
     ESP_ERROR_CHECK(gpio_install_isr_service(0));
@@ -618,6 +628,8 @@ static void startDevice() {
             deviceConfirmedRequestedAt = deviceStoredConfig.requestedAt();
         }
     }
+
+    logHeapCheckpoint("after device/config-state load");
 
     const std::string modelWithRevision = deviceDefinition->model + " (rev" + std::to_string(deviceDefinition->revision) + ")";
 
@@ -750,6 +762,7 @@ static void startDevice() {
     MqttLog::init(deviceConfig->publishLogs.get(), logRecords, mqttRoot);
     registerBasicCommands(mqttRoot);
     registerNvsCommands(mqttRoot);
+    logHeapCheckpoint("after mqtt init");
 
     // SYNC trigger: a single-element overwrite queue coalesces every successful (re)connection
     // (docs/Configuration.md, "BOOT, SYNC, UPDATE") plus post-UPDATE requests into one pending
@@ -811,6 +824,7 @@ static void startDevice() {
     };
     registerUpdateHandler(mqttRoot, deviceConfirmedFingerprint, functionRegistry, configStateStore, syncTriggerQueue);
     initSyncTask(mqttRoot, syncTriggerQueue, states, functionRegistry, deviceManifestEntry, pendingSyncRejection);
+    logHeapCheckpoint("after update handler + sync task registered");
 
     // Init telemetry
     mqttRoot->registerCommand("ping", [telemetryPublisher](const JsonObject&, JsonObject& response) {
@@ -847,6 +861,7 @@ static void startDevice() {
 
     // Start ULP pulse counter after all channels have been registered by peripherals above.
     pulseCounterManager->start();
+    logHeapCheckpoint("after peripherals init");
 
     JsonDocument functionsInitDoc;
     auto functionsInitJson = functionsInitDoc.to<JsonArray>();
@@ -858,6 +873,7 @@ static void startDevice() {
             initState = InitState::FunctionError;
         }
     }
+    logHeapCheckpoint("after functions init");
 
     // Booting a `requested` set is strict (docs/Configuration.md, "The confirmed/requested state
     // machine"): unlike `confirmed` (or the empty-slot default), which boots best-effort regardless
@@ -940,6 +956,8 @@ static void startDevice() {
             CrashManager::handleCrashReport(json);
         },
         Retention::NoRetain, QoS::AtLeastOnce, 5s);
+
+    logHeapCheckpoint("before kernelReady");
 
     states->kernelReady.set();
 

--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -755,6 +755,8 @@ static void startDevice() {
     wifi->setOnStatusChanged([ble](const std::string& status) {
         ble->setWifiStatus(status);
     });
+    states->networkReady.awaitSet();
+    logHeapCheckpoint("after wifi connected + rtc sync (before peripherals)");
 
     // Init MQTT connection
     auto clientId = "ugly-duckling-" + macAddress;
@@ -773,6 +775,8 @@ static void startDevice() {
     mqttRoot->mqtt->onConnected([syncTriggerQueue]() {
         syncTriggerQueue->overwrite(true);
     });
+    states->mqttReady.awaitSet();
+    logHeapCheckpoint("mqtt connected (TLS handshake complete)");
 
     // Holds this boot's rejection code (if any) for the SYNC task to attach to the first SYNC it
     // publishes -- populated below, once the strict-boot outcome is known, strictly before


### PR DESCRIPTION
Apparently after introducing the new two-slot configuration rollback mechanism, we introduced a bunch of additional memory usage that is likely a leak.

<img width="1328" height="175" alt="image" src="https://github.com/user-attachments/assets/026bbeee-09c6-4c8a-bb61-726a276df5da" />

Orange is `potyi-1` (MK11), green is `garden-mains` (MK6r3).