### PR TITLE
Fix extreme flow rates being reported

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -2,9 +2,30 @@
   "version": 4,
   "configurations": [
     {
-      "name": "Production",
+      "name": "Production (carrot)",
       "compileCommands": [
-        "${config:idf.buildPath}/compile_commands.json"
+        "${workspaceFolder}/build-carrot/compile_commands.json"
+      ],
+      "includePath": [
+        "${config:idf.espIdfPath}/components",
+        "${config:idf.espIdfPathWin}/components",
+        "${workspaceFolder}/components/**",
+        "${workspaceFolder}/managed_components/**"
+      ],
+      "browse": {
+        "path": [
+          "${config:idf.espIdfPath}/components",
+          "${config:idf.espIdfPathWin}/components",
+          "${workspaceFolder}"
+        ],
+        "limitSymbolsToIncludedHeaders": true
+      },
+      "cppStandard": "c++26"
+    },
+    {
+      "name": "Production (spinach)",
+      "compileCommands": [
+        "${workspaceFolder}/build-spinach/compile_commands.json"
       ],
       "includePath": [
         "${config:idf.espIdfPath}/components",

--- a/components/kernel/src/PulseCounter.cpp
+++ b/components/kernel/src/PulseCounter.cpp
@@ -73,27 +73,34 @@ namespace cornucopia::ugly_duckling::kernel {
 class UlpPulseCounter final : public PulseCounter {
 public:
     uint32_t getCount() const override {
-        if (ulp_running == 0U) {
-            // ULP not running, so the count won't be changing
-            return lastSeen;
+        if (ulp_started == 0U) {
+            // ULP not started yet, so no new pulses have been counted since lastSeen
+            return 0;
         }
         uint32_t current = ulp_pulse_count[channelIndex];
+        if (isDesynced(current)) {
+            return 0;
+        }
         uint32_t delta = current - lastSeen;
-        LOGTV(PULSE, "Counted %" PRIu32 " ULP pulses on pin %s, ULP running: %d",
-            delta, pin->getName().c_str(), ulp_running);
+        LOGTV(PULSE, "Counted %" PRIu32 " ULP pulses on pin %s, ULP started: %d",
+            delta, pin->getName().c_str(), ulp_started);
         return delta;
     }
 
     uint32_t reset() override {
-        if (ulp_running == 0U) {
-            // ULP not running, so the count won't be changing
-            return lastSeen;
+        if (ulp_started == 0U) {
+            // ULP not started yet, so no new pulses have been counted since lastSeen
+            return 0;
         }
         uint32_t current = ulp_pulse_count[channelIndex];
+        if (isDesynced(current)) {
+            lastSeen = current;
+            return 0;
+        }
         uint32_t delta = current - lastSeen;
         lastSeen = current;
-        LOGTV(PULSE, "Counted %" PRIu32 " ULP pulses and cleared on pin %s, ULP running: %d",
-            delta, pin->getName().c_str(), ulp_running);
+        LOGTV(PULSE, "Counted %" PRIu32 " ULP pulses and cleared on pin %s, ULP started: %d",
+            delta, pin->getName().c_str(), ulp_started);
         return delta;
     }
 
@@ -105,6 +112,23 @@ private:
     UlpPulseCounter(InternalPinPtr pin, uint32_t channelIndex)
         : pin(std::move(pin))
         , channelIndex(channelIndex) {
+    }
+
+    // Detects a coprocessor/CPU desync: current - lastSeen wraps around to a
+    // huge unsigned delta whenever current < lastSeen (e.g. the ULP-side counter
+    // was reset or corrupted in RTC slow memory, e.g. by a brownout/EMI). Checking
+    // the subtraction as a signed int32 catches exactly that case, since a "borrow"
+    // in the unsigned subtraction always produces a bit pattern that reads negative
+    // when reinterpreted as two's-complement — regardless of how large the
+    // (bogus) unsigned delta would have been. See issue #608.
+    bool isDesynced(uint32_t current) const {
+        auto delta = static_cast<int32_t>(current - lastSeen);
+        if (delta < 0) {
+            LOGTE(PULSE, "ULP pulse counter desync on pin %s (channel %" PRIu32 "): current=%" PRIu32 " < lastSeen=%" PRIu32 ", discarding delta",
+                pin->getName().c_str(), channelIndex, current, lastSeen);
+            return true;
+        }
+        return false;
     }
 
     const InternalPinPtr pin;
@@ -172,13 +196,13 @@ void PulseCounterManager::start() {
     uint32_t sensState = REG_READ(SENS_SAR_COCPU_STATE_REG);
     uint32_t intRaw = REG_READ(RTC_CNTL_INT_RAW_REG);
     // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,performance-no-int-to-ptr)
-    LOGTD(PULSE, "COCPU_CTRL=0x%" PRIx32 " SENSE=0x%" PRIx32 " DONE=%d TRAP=%d TRAP_INT_RAW=%d running=%" PRIu32,
+    LOGTD(PULSE, "COCPU_CTRL=0x%" PRIx32 " SENSE=0x%" PRIx32 " DONE=%d TRAP=%d TRAP_INT_RAW=%d started=%" PRIu32,
         cocpuCtrl,
         sensState,
         static_cast<int>((cocpuCtrl & RTC_CNTL_COCPU_DONE_M) != 0),
         static_cast<int>((sensState & SENS_COCPU_TRAP_M) != 0),
         static_cast<int>((intRaw & RTC_CNTL_COCPU_TRAP_INT_RAW_M) != 0),
-        ulp_running);
+        ulp_started);
 #endif
 #elif defined(CONFIG_ULP_COPROC_TYPE_LP_CORE)
     ulp_lp_core_cfg_t cfg = {

--- a/components/kernel/ulp/pulse_counter.c
+++ b/components/kernel/ulp/pulse_counter.c
@@ -55,7 +55,7 @@ volatile uint32_t channel_count;
 volatile uint32_t gpio_num[MAX_CHANNELS];
 
 /** Set to 1 on the first instruction of main(). Used by the main CPU to confirm startup. */
-volatile uint32_t running;
+volatile uint32_t started;
 
 /**
  * Debounce window in microseconds. Written by main CPU before coprocessor starts.
@@ -77,7 +77,7 @@ static uint32_t last_edge_cycle[MAX_CHANNELS];
 static uint32_t debounce_cycles[MAX_CHANNELS];
 
 int main(void) {
-    running = 1;
+    started = 1;
     uint32_t n = channel_count;
 
     for (uint32_t gpio_idx = 0; gpio_idx < n; gpio_idx++) {


### PR DESCRIPTION
## Summary

Fixes #608 — momentary extreme flow-rate/volume spikes from flow meters, traced to a `uint32_t` wraparound in `UlpPulseCounter`'s delta computation.

- `getCount()`/`reset()` computed `current - lastSeen` as an unsigned subtraction with no guard against `current < lastSeen`. If the ULP/LP-core counter in RTC slow memory ever goes backwards relative to the cached `lastSeen` (e.g. RTC memory corruption from a brownout/EMI/ESD event), the subtraction wraps to a value near `UINT32_MAX` — reporting billions of phantom pulses in a single tick.
- Added a guard (`isDesynced()`) that checks the subtraction as a signed `int32_t`: a negative result means the unsigned subtraction "borrowed", i.e. `current < lastSeen`. On desync, logs `LOGTE(PULSE, ...)` with the actual `current`/`lastSeen` values and pin/channel, and discards the wrapped delta instead of propagating it (`reset()` also resyncs `lastSeen` to `current`).
- Also fixed a related bug found while reviewing this code: `getCount()`/`reset()` returned `lastSeen` (the raw cumulative counter) instead of `0` when the ULP hadn't started yet — which would have re-reported the entire historical count as a fresh delta on every call in that state. Confirmed via inspection of `ulp/pulse_counter.c` that this was latent (unreachable with a nonzero `lastSeen` in the current boot sequence) rather than the cause of the reported incidents, but it's the correct contract regardless.
- Renamed the ULP-exported `running`/`ulp_running` flag to `started`/`ulp_started`: it's a one-shot flag set once as the first instruction of the ULP's `main()` and never toggled again, not a live busy/idle indicator — the old name was misleading.

Confirmed via inspection of the ULP firmware (`components/kernel/ulp/pulse_counter.c`) that the coprocessor itself never resets `pulse_count[]` during steady-state polling (increment-only on debounced falling edge) — the only reset is the one-time zero-init in `PulseCounterManager::start()` before the coprocessor launches. So any `current < lastSeen` observed by the guard is genuine desync/corruption, not a legitimate wraparound from normal ULP logic.

Not included (can follow up separately if wanted): the plausibility-ceiling clamp on pulses-per-tick suggested in the issue, and a dedicated unit/embedded test for the wraparound guard.

## Testing

- Target platform: `carrot` (ESP32-C6). Not built for `spinach` — this file's ULP path is already conditional on `CONFIG_ULP_COPROC_TYPE_RISCV`/`CONFIG_ULP_COPROC_TYPE_LP_CORE`, and the change doesn't touch Spinach-specific code, so carrot coverage is representative.
- `. tools/activate_idf.sh carrot && idf.py -B build-carrot build` — passed (`Project build complete.`, exit 0), both before and after the `running`→`started` rename.
- No automated test added yet for the wraparound guard itself (flagged above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)