### PR TITLE
Decouple publish-ack wait from the calling task's notification slot

### DIFF
--- a/components/kernel/src/mqtt/MqttDriver.hpp
+++ b/components/kernel/src/mqtt/MqttDriver.hpp
@@ -210,7 +210,7 @@ private:
         std::string payload;
         Retention retain;
         QoS qos;
-        TaskHandle_t waitingTask;
+        PendingMessagePtr pending;
         LogPublish log;
     };
 
@@ -275,7 +275,9 @@ private:
     }
 
     PublishStatus publishAndWait(const std::string& topic, const std::string& payload, Retention retain, QoS qos, ticks timeout) {
-        TaskHandle_t waitingTask = timeout == ticks::zero() ? nullptr : xTaskGetCurrentTaskHandle();
+        // Fire-and-forget publishes (timeout == 0) don't get a pending-outcome slot at all --
+        // there's nobody around to wait on it.
+        auto pending = timeout == ticks::zero() ? nullptr : std::make_shared<PendingMessage>();
 
         bool offered = eventQueue.offerIn(
             MQTT_QUEUE_TIMEOUT,
@@ -284,28 +286,21 @@ private:
                 .payload = payload,
                 .retain = retain,
                 .qos = qos,
-                .waitingTask = waitingTask,
+                .pending = pending,
                 .log = LogPublish::Log,
             });
 
         if (!offered) {
             return PublishStatus::QueueFull;
         }
-        if (waitingTask == nullptr) {
+        if (pending == nullptr) {
             return PublishStatus::Pending;
         }
 
-        // Wait for task notification
-        auto status = static_cast<PublishStatus>(ulTaskNotifyTake(pdTRUE, timeout.count()));
-        switch (status) {
-            case PublishStatus::TimeOut:
-                pendingMessages.cancelWaitingOn(waitingTask);
-                return PublishStatus::TimeOut;
-            case PublishStatus::Success:
-                return PublishStatus::Success;
-            default:
-                return PublishStatus::Failed;
-        }
+        // This timeout is purely how long *this call* is willing to block -- if it expires
+        // before the real outcome arrives, we just stop waiting; `pending` keeps the outcome
+        // slot alive for whoever (if anyone) still holds a reference to it (see PendingMessages).
+        return pending->await(timeout);
     }
 
     bool subscribe(const std::string& topic, QoS qos, SubscriptionHandler handler) {
@@ -585,7 +580,9 @@ private:
         if (ret < 0) {
             LOGTD(MQTT, "Error publishing to '%s': %s",
                 message.topic.c_str(), ret == -2 ? "outbox full" : "failure");
-            PendingMessages::notifyWaitingTask(message.waitingTask, false);
+            if (message.pending != nullptr) {
+                message.pending->resolve(PublishStatus::Failed);
+            }
         } else {
             auto messageId = ret;
 #ifdef DUMP_MQTT
@@ -594,7 +591,7 @@ private:
                     message.topic.c_str(), message.payload.length(), messageId);
             }
 #endif
-            pendingMessages.waitOn(messageId, message.waitingTask);
+            pendingMessages.waitOn(messageId, message.pending);
         }
     }
 

--- a/components/kernel/src/mqtt/PendingMessages.hpp
+++ b/components/kernel/src/mqtt/PendingMessages.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <memory>
 #include <unordered_map>
 
 #include <Concurrent.hpp>
-#include <Task.hpp>
 
 namespace cornucopia::ugly_duckling::kernel::mqtt {
 
@@ -15,27 +15,69 @@ enum class PublishStatus : uint8_t {
     QueueFull = 4
 };
 
-static constexpr uint32_t PUBLISH_SUCCESS = 1;
-static constexpr uint32_t PUBLISH_FAILED = 2;
+/**
+ * @brief One-shot outcome slot for a single publish, identified by nothing but its own identity
+ * (there's exactly one of these per in-flight `publishAndWait` call). Resolved at most once, by
+ * whichever side gets there first: the real MQTT outcome (ack/fail/disconnect-cleanup), or the
+ * caller giving up locally. A caller that stops waiting (timeout) simply drops its reference;
+ * if the real outcome arrives later it resolves an object nobody's listening to anymore instead
+ * of racing a stale notification onto some *other*, unrelated wait -- there's no shared channel
+ * left to cross-talk over.
+ *
+ * Lifetime is shared between `PendingMessages` (which holds it by message ID until the outcome
+ * arrives or the connection drops) and the waiting call stack, via `shared_ptr`: whichever side
+ * lets go last is the one that frees it, so it's never leaked and never double-resolved.
+ */
+class PendingMessage {
+public:
+    PendingMessage()
+        : outcome("mqtt-pending-message", 1) {
+    }
+
+    PendingMessage(const PendingMessage&) = delete;
+    PendingMessage& operator=(const PendingMessage&) = delete;
+
+    /**
+     * @brief Resolves the outcome. Must be called at most once (a second call would find the
+     * one-slot queue already full and just print an overflow warning instead of blocking).
+     */
+    void resolve(PublishStatus status) {
+        outcome.offer(status);
+    }
+
+    /**
+     * @brief Blocks the calling task until `resolve()` is called or `timeout` elapses.
+     */
+    PublishStatus await(ticks timeout) {
+        return outcome.pollIn(timeout).value_or(PublishStatus::TimeOut);
+    }
+
+private:
+    CopyQueue<PublishStatus> outcome;
+};
+
+using PendingMessagePtr = std::shared_ptr<PendingMessage>;
 
 class PendingMessages {
 public:
-    bool waitOn(int messageId, TaskHandle_t waitingTask) {
-        if (waitingTask == nullptr) {
-            // Nothing is waiting
-            return false;
+    /**
+     * @brief Registers `pending` as awaiting the outcome of `messageId`, unless it's resolved
+     * immediately: `pending` may be null (fire-and-forget publish, nobody is waiting), and
+     * QoS 0 messages never get a PUBLISHED/DELETED event from esp-mqtt, so they're resolved as
+     * successful right away instead of being tracked.
+     */
+    void waitOn(int messageId, const PendingMessagePtr& pending) {
+        if (pending == nullptr) {
+            return;
         }
 
         if (messageId == 0) {
-            // Notify tasks waiting on QoS 0 messages immediately
-            notifyWaitingTask(waitingTask, true);
-            return false;
+            pending->resolve(PublishStatus::Success);
+            return;
         }
 
-        // Record pending task
         Lock lock(mutex);
-        messages[messageId] = waitingTask;
-        return true;
+        messages[messageId] = pending;
     }
 
     bool handlePublished(int messageId, bool success) {
@@ -43,52 +85,35 @@ public:
             return false;
         }
 
-        Lock lock(mutex);
-        auto it = messages.find(messageId);
-        if (it != messages.end()) {
-            notifyWaitingTask(it->second, success);
-            messages.erase(it);
-            return true;
-        }
-        return false;
-    }
-
-    bool cancelWaitingOn(TaskHandle_t waitingTask) {
-        if (waitingTask == nullptr) {
-            return false;
-        }
-
-        Lock lock(mutex);
-        bool removed = false;
-        for (auto it = messages.begin(); it != messages.end();) {
-            if (it->second == waitingTask) {
-                it = messages.erase(it);
-                removed = true;
-            } else {
-                ++it;
+        PendingMessagePtr pending;
+        {
+            Lock lock(mutex);
+            auto it = messages.find(messageId);
+            if (it == messages.end()) {
+                return false;
             }
+            pending = std::move(it->second);
+            messages.erase(it);
         }
-        return removed;
+        pending->resolve(success ? PublishStatus::Success : PublishStatus::Failed);
+        return true;
     }
 
     void clear() {
-        Lock lock(mutex);
-        for (auto& [messageId, waitingTask] : messages) {
-            notifyWaitingTask(waitingTask, false);
+        std::unordered_map<int, PendingMessagePtr> abandoned;
+        {
+            Lock lock(mutex);
+            abandoned = std::move(messages);
+            messages.clear();
         }
-        messages.clear();
-    }
-
-    static void notifyWaitingTask(TaskHandle_t task, bool success) {
-        if (task != nullptr) {
-            auto status = success ? PublishStatus::Success : PublishStatus::Failed;
-            xTaskNotify(task, static_cast<int>(status), eSetValueWithOverwrite);
+        for (auto& [messageId, pending] : abandoned) {
+            pending->resolve(PublishStatus::Failed);
         }
     }
 
 private:
     Mutex mutex;
-    std::unordered_map<int, TaskHandle_t> messages;
+    std::unordered_map<int, PendingMessagePtr> messages;
 };
 
 }    // namespace cornucopia::ugly_duckling::kernel::mqtt


### PR DESCRIPTION
## Problem

`MqttDriver::publishAndWait` parked the calling task on its own raw FreeRTOS
task-notification slot (`ulTaskNotifyTake`/`xTaskNotify`), tracked by message
ID in `PendingMessages`. If the local wait timed out before the real MQTT
outcome arrived (esp-mqtt retransmits every `message_retransmit_timeout` --
5s -- and only gives up via outbox expiry after ~30s while the connection
stays up), `PendingMessages::cancelWaitingOn` removed the pending-message
entry so the eventual real ack/fail was silently dropped when it did arrive.

This wasn't just "the timeout is too short" -- it was structural: because the
ack channel was a single per-task notification slot (not per-call), a late
notification couldn't simply be let through once the local wait gave up --
if the same task had since started a *different* `publishAndWait` call, the
stale notification could wrongly resolve the new, unrelated wait.

## Fix

Replace the shared notification slot with a `PendingMessage`: a one-shot
outcome slot scoped to a single in-flight publish, built on
`CopyQueue<PublishStatus>` (`Concurrent.hpp`, capacity 1) rather than a raw
FreeRTOS primitive -- one blocking-with-timeout wait that also carries the
result value.

Lifetime is shared between `PendingMessages`' map (keyed by message ID) and
the waiting call stack via `shared_ptr`: whichever side lets go last frees
it. A caller that gives up locally (timeout) just drops its reference; if
the real outcome arrives later it resolves an object nobody's listening to
anymore instead of racing a stale notification onto an unrelated wait --
there's no shared channel left to cross-talk over. `Disconnected` cleanup
(`PendingMessages::clear()`) still resolves every still-pending entry, now
via the shared owner instead of a raw task notification.

`cancelWaitingOn` is gone -- no longer needed, since giving up locally
requires no bookkeeping now.

Timeout values at existing call sites (`MQTT_NETWORK_TIMEOUT` default,
boot's explicit 5s, log's explicit 2s) are unchanged; this PR is scoped to
the structural fix only.

Follow-up to #579 / #610 (merged separately) -- independent of that
QoS-level fix.

## Testing

- `IDF_TARGET`: `esp32c6` (carrot). Not platform-conditional (TCP/MQTT client
  machinery, not device/peripheral code) -- `spinach` not built.
- `. tools/build.sh carrot build` -- exit 0, "Project build complete."
- No native unit tests added: `PendingMessages`/`MqttDriver` pull in real
  FreeRTOS headers (`Concurrent.hpp`/`Task.hpp`) with no native shim
  anywhere in `test/unit-tests/` (which already excludes `State.cpp` for the
  same reason). Adding coverage would require building a FreeRTOS-for-native
  shim first -- treated as out of scope for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)