### PR TITLE
Catch MQTT config errors instead of crashing the task

### DIFF
--- a/components/kernel/src/mqtt/MqttDriver.hpp
+++ b/components/kernel/src/mqtt/MqttDriver.hpp
@@ -453,7 +453,16 @@ private:
         stopClient();
 
         esp_mqtt_client_config_t mqttConfig { };
-        configMqttClient(mqttConfig);
+        try {
+            configMqttClient(mqttConfig);
+        } catch (const std::exception& e) {
+            // Config is loaded once at startup and won't fix itself without a reboot, but we
+            // still just leave the state machine to retry on its normal cadence (see the
+            // Connecting-state timeout in runEventLoop()) rather than special-casing a backoff --
+            // the client was never started, so that retry is as cheap as this one was.
+            LOGTE(MQTT, "Cannot configure MQTT client, not connecting: %s", e.what());
+            return;
+        }
         mqttConfig.session.disable_clean_session = !startCleanSession;
         esp_mqtt_set_config(client, &mqttConfig);
         LOGTI(MQTT, "Connecting to %s:%" PRIu32 ", clean session: %d",
@@ -464,8 +473,12 @@ private:
 
     void disconnect() {
         ready.clear();
-        LOGTD(MQTT, "Disconnecting from MQTT server");
-        ESP_ERROR_CHECK(esp_mqtt_client_disconnect(client));
+        // Guard against disconnecting a client that was never started -- e.g. connect() bailed
+        // out above because of a config error, so esp_mqtt_client_start() was never called.
+        if (clientRunning) {
+            LOGTD(MQTT, "Disconnecting from MQTT server");
+            ESP_ERROR_CHECK(esp_mqtt_client_disconnect(client));
+        }
         stopClient();
     }
 


### PR DESCRIPTION
## Summary

Fixes #598. `MqttDriver::connect()` called `configMqttClient()` unguarded, which throws `std::runtime_error` when the configured MQTT `host` is empty (e.g. missing/malformed `network-config`). Nothing caught this before the FreeRTOS task entry point, so the device hard-crashed right as WiFi came up — misleading, since it looked WiFi-related but was actually an MQTT config problem.

## Fix

Rather than wrapping the whole task body, the exception is caught right where the config is consumed, in `connect()`:

- Log the error clearly (`LOGTE`) and skip this connection attempt instead of starting the client.
- The existing `Connecting`-state timeout in `runEventLoop()` (~15s) then naturally retries, same cadence as any other connection failure (bad DNS, refused connection, etc.) — no new backoff logic needed.
- `disconnect()` previously assumed the client was always started before being called (that path was unreachable before, since a throw always crashed the task first). Guarded it with the existing `clientRunning` flag since the config-error path can now reach it without ever starting the client.

## Testing

- Target platform: `carrot` (ESP32-C6). Not Spinach-specific — MQTT config loading is platform-agnostic.
- `. tools/activate_idf.sh carrot && idf.py -B build-carrot build` — succeeded (`Project build complete.`).
- No NVS config schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)