### PR TITLE
Format codebase consistently

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 BasedOnStyle: WebKit
 AlignTrailingComments: true
+AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: true
@@ -10,3 +11,16 @@ CompactNamespaces: true
 FixNamespaceComments: true
 NamespaceIndentation: None
 PointerAlignment: Left
+
+SortIncludes: CaseSensitive
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Project headers (.hpp)
+  - Regex: '\.hpp[">]$'
+    Priority: 1
+  # ESP-IDF, third-party, and C headers (.h)
+  - Regex: '\.h[">]$'
+    Priority: 2
+  # C++ standard library (no extension)
+  - Regex: '.*'
+    Priority: 3

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Format staged C++ files with the project's clang-format before committing.
+# Installed automatically by tools/activate_idf.sh via core.hooksPath.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FILES=$(git diff --cached --name-only --diff-filter=d | grep -E '\.(cpp|hpp)$')
+
+if [ -z "$FILES" ]; then
+    exit 0
+fi
+
+# Format and re-stage
+echo "$FILES" | xargs "$PROJECT_DIR/tools/clang-format.sh" -i
+echo "$FILES" | xargs git add

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,17 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           ls -l build/*.bin build/bootloader/bootloader.bin build/partition_table/partition-table.bin
 
+      - name: clang-format
+        if: matrix.ud_debug == 0
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: ${{ env.ESP_IDF_VERSION }}
+          esp_idf_docker_image: lptr/esp-idf-clang
+          target: ${{ matrix.target }}
+          command: |
+            find main components -type f \( -name '*.cpp' -o -name '*.hpp' \) -not -path '*/test/*' -not -path '*/build/*' | xargs clang-format -i
+            git diff --exit-code --stat || { echo "::error::Files above need clang-format. Run: find main components -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i"; exit 1; }
+
       - name: clang-tidy
         if: matrix.ud_debug == 0
         uses: espressif/esp-idf-ci-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-/.vscode/*
-!/.vscode/launch.json
-!/.vscode/c_cpp_properties.json
-
 *.log
 
 # Clangd cache

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "llvm-vs-code-extensions.vscode-clangd",
+    "espressif.esp-idf-extension"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "C_Cpp.intelliSenseEngine": "default",
+  "editor.formatOnSave": true,
+  "idf.customExtraVars": {
+    "IDF_TARGET": "esp32c6"
+  },
+  "idf.openOcdConfigs": [
+    "board/esp32c6-builtin.cfg"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "C_Cpp.intelliSenseEngine": "default",
+  "C_Cpp.clang_format_path": "${workspaceFolder}/tools/clang-format.sh",
   "editor.formatOnSave": true,
   "idf.customExtraVars": {
     "IDF_TARGET": "esp32c6"

--- a/components/devices/src/BootConfig.cpp
+++ b/components/devices/src/BootConfig.cpp
@@ -1,13 +1,13 @@
 #include "NvsStore.hpp"
-#include "config/ConfigStateStore.hpp"
-#include "config/ConfigState.hpp"
 #include "config/ConfigBootPlan.hpp"
+#include "config/ConfigState.hpp"
+#include "config/ConfigStateStore.hpp"
 #include "devices/DeviceConfiguration.hpp"
 #include <BootConfig.hpp>
-
 #include <Log.hpp>
 #include <UpdateFilter.hpp>
 #include <config/StoredConfig.hpp>
+
 #include <memory>
 
 using namespace cornucopia::ugly_duckling::devices;

--- a/components/devices/src/BootConfig.hpp
+++ b/components/devices/src/BootConfig.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <memory>
-#include <string>
-
 #include <NvsStore.hpp>
 #include <config/ConfigBootPlan.hpp>
 #include <config/ConfigState.hpp>
 #include <config/ConfigStateStore.hpp>
-
 #include <devices/DeviceConfiguration.hpp>
+
+#include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::devices;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/devices/src/BootHelpers.cpp
+++ b/components/devices/src/BootHelpers.cpp
@@ -10,23 +10,26 @@
 #include "drivers/BatteryDriver.hpp"
 #include "drivers/BleDriver.hpp"
 #include "drivers/LedDriver.hpp"
+#include <BootHelpers.hpp>
+#include <Log.hpp>
+
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_system.h"
 #include "nvs.h"
-#include <BootHelpers.hpp>
-#include <Log.hpp>
 
 #ifdef CONFIG_BT_NIMBLE_ENABLED
 #include "NvsStore.hpp"
 #endif
 
 #include <Restart.hpp>
-#include <chrono>
-#include <esp_wifi.h>
-#include <memory>
 #include <mqtt/MqttDriver.hpp>
+
+#include <esp_wifi.h>
 #include <nvs_flash.h>
+
+#include <chrono>
+#include <memory>
 #include <string>
 
 using namespace std::chrono;

--- a/components/devices/src/BootHelpers.hpp
+++ b/components/devices/src/BootHelpers.hpp
@@ -1,20 +1,19 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-#include <string>
-
 #include <BatteryManager.hpp>
 #include <KernelStatus.hpp>
+#include <NetworkConfig.hpp>
 #include <NvsStore.hpp>
 #include <Watchdog.hpp>
+#include <devices/DeviceConfiguration.hpp>
+#include <devices/DeviceDefinition.hpp>
 #include <drivers/BleDriver.hpp>
 #include <drivers/LedDriver.hpp>
 #include <mqtt/MqttRoot.hpp>
 
-#include <NetworkConfig.hpp>
-#include <devices/DeviceConfiguration.hpp>
-#include <devices/DeviceDefinition.hpp>
+#include <chrono>
+#include <memory>
+#include <string>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::devices;

--- a/components/devices/src/BootMessage.cpp
+++ b/components/devices/src/BootMessage.cpp
@@ -1,17 +1,18 @@
-#include "esp_attr.h"
-#include "mqtt/MqttRoot.hpp"
-#include "esp_system.h"
+#include "FirmwareRollback.hpp"
+#include "HardwareVersion.hpp"
 #include "NetworkConfig.hpp"
 #include "PowerManager.hpp"
-#include "devices/DeviceDefinition.hpp"
-#include "HardwareVersion.hpp"
 #include "config/ConfigState.hpp"
-#include "FirmwareRollback.hpp"
-#include "esp_sleep.h"
+#include "devices/DeviceDefinition.hpp"
 #include "mqtt/MqttDriver.hpp"
+#include "mqtt/MqttRoot.hpp"
 #include <BootMessage.hpp>
 
+#include "esp_attr.h"
+#include "esp_sleep.h"
+#include "esp_system.h"
 #include <bits/chrono.h>
+
 #include <chrono>
 
 namespace {
@@ -20,11 +21,11 @@ RTC_DATA_ATTR int bootCount = 0;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 }    // namespace
 
+#include <CrashManager.hpp>
+
 #include <memory>
 #include <optional>
 #include <string>
-
-#include <CrashManager.hpp>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/devices/src/BootMessage.hpp
+++ b/components/devices/src/BootMessage.hpp
@@ -1,19 +1,18 @@
 #pragma once
 
+#include <FirmwareRollback.hpp>
+#include <HardwareVersion.hpp>
+#include <NetworkConfig.hpp>
+#include <PowerManager.hpp>
+#include <config/ConfigState.hpp>
+#include <devices/DeviceDefinition.hpp>
+#include <mqtt/MqttRoot.hpp>
+
 #include <chrono>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
-
-#include <FirmwareRollback.hpp>
-#include <HardwareVersion.hpp>
-#include <PowerManager.hpp>
-#include <config/ConfigState.hpp>
-
-#include <NetworkConfig.hpp>
-#include <devices/DeviceDefinition.hpp>
-#include <mqtt/MqttRoot.hpp>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::devices;

--- a/components/devices/src/ConfigUpdate.cpp
+++ b/components/devices/src/ConfigUpdate.cpp
@@ -1,26 +1,24 @@
-#include "functions/Function.hpp"
-#include "config/ConfigStateStore.hpp"
 #include "NvsStore.hpp"
-#include "mqtt/MqttRoot.hpp"
 #include "Queue.hpp"
+#include "config/ConfigStateStore.hpp"
+#include "functions/Function.hpp"
 #include "mqtt/MqttDriver.hpp"
+#include "mqtt/MqttRoot.hpp"
 #include <ConfigUpdate.hpp>
-#include <Log.hpp>
-
-#include <exception>
-#include <memory>
-#include <string>
-#include <unordered_map>
-
 #include <FirmwareUpdateDecision.hpp>
 #include <HttpUpdate.hpp>
-
+#include <Log.hpp>
 #include <Restart.hpp>
 #include <UpdateFilter.hpp>
 #include <config/ConfigBootPlan.hpp>
 #include <config/ConfigStaging.hpp>
 #include <config/ConfigState.hpp>
 #include <config/StoredConfig.hpp>
+
+#include <exception>
+#include <memory>
+#include <string>
+#include <unordered_map>
 
 using namespace cornucopia::ugly_duckling::functions;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/devices/src/ConfigUpdate.hpp
+++ b/components/devices/src/ConfigUpdate.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <cstdint>
-#include <memory>
-#include <string>
-
 #include <NvsStore.hpp>
 #include <Queue.hpp>
 #include <config/ConfigStateStore.hpp>
@@ -11,16 +7,20 @@
 #include <functions/Function.hpp>
 #include <mqtt/MqttRoot.hpp>
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 using namespace cornucopia::ugly_duckling::functions;
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::config;
 using namespace cornucopia::ugly_duckling::kernel::mqtt;
 
 enum class ConfigUpdateResult : std::uint8_t {
-    NoChanges,          // configurations absent or nothing differs from what's held
-    DeviceChanged,      // staged into free slot, needs reboot to apply
-    FunctionsApplied,   // hot-reloaded live, succeeded and committed
-    FunctionsFailed,    // hot-reload failed, needs reboot to revert
+    NoChanges,           // configurations absent or nothing differs from what's held
+    DeviceChanged,       // staged into free slot, needs reboot to apply
+    FunctionsApplied,    // hot-reloaded live, succeeded and committed
+    FunctionsFailed,     // hot-reload failed, needs reboot to revert
 };
 
 /**

--- a/components/devices/src/Connectivity.cpp
+++ b/components/devices/src/Connectivity.cpp
@@ -1,14 +1,15 @@
 #include "KernelStatus.hpp"
 #include "NetworkConfig.hpp"
 #include "drivers/BleDriver.hpp"
-#include "drivers/WiFiDriver.hpp"
 #include "drivers/RtcDriver.hpp"
+#include "drivers/WiFiDriver.hpp"
 #include "drivers/WifiApRecord.hpp"
 #include <Connectivity.hpp>
-#include <memory>
+
 #include <ctime>
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/devices/src/Connectivity.hpp
+++ b/components/devices/src/Connectivity.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <memory>
-
 #include <KernelStatus.hpp>
+#include <NetworkConfig.hpp>
 #include <drivers/BleDriver.hpp>
 #include <drivers/RtcDriver.hpp>
 #include <drivers/WiFiDriver.hpp>
 
-#include <NetworkConfig.hpp>
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/devices/src/Device.hpp
+++ b/components/devices/src/Device.hpp
@@ -8,42 +8,39 @@
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 
+#include <esp_app_desc.h>
+
 #include <chrono>
 #include <concepts>
 #include <memory>
 #include <string>
 
-#include <esp_app_desc.h>
-
 static const std::string firmwareVersion(esp_app_get_description()->version);
-
-#include <Console.hpp>
-#include <DebugConsole.hpp>
-#include <FirmwareRollback.hpp>
-#include <HardwareVersion.hpp>
-#include <HttpUpdate.hpp>
-#include <Log.hpp>
-#include <ShutdownManager.hpp>
-#include <Strings.hpp>
-#include <config/ConfigBootPlan.hpp>
-#include <config/NvsConfiguration.hpp>
-#include <mqtt/MqttLog.hpp>
-
-#include <devices/DeviceDefinition.hpp>
-
-#include <MacAddress.hpp>
 
 #include <BootConfig.hpp>
 #include <BootHelpers.hpp>
 #include <BootMessage.hpp>
 #include <ConfigUpdate.hpp>
 #include <Connectivity.hpp>
+#include <Console.hpp>
+#include <DebugConsole.hpp>
 #include <DeviceInit.hpp>
+#include <FirmwareRollback.hpp>
+#include <HardwareVersion.hpp>
 #include <HeapTrace.hpp>
+#include <HttpUpdate.hpp>
+#include <Log.hpp>
+#include <MacAddress.hpp>
 #include <MqttCommands.hpp>
 #include <NetworkConfig.hpp>
+#include <ShutdownManager.hpp>
+#include <Strings.hpp>
 #include <SyncPublisher.hpp>
 #include <TelemetryTask.hpp>
+#include <config/ConfigBootPlan.hpp>
+#include <config/NvsConfiguration.hpp>
+#include <devices/DeviceDefinition.hpp>
+#include <mqtt/MqttLog.hpp>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::devices;
@@ -129,7 +126,7 @@ static void startDevice() {
 
     // Init switch and button handling
     auto switches = std::make_shared<SwitchManager>();
-    switches->registerSwitch({
+    switches->registerSwitch({ //
         .name = "factory-reset",
         .pin = deviceDefinition->bootPin,
         .mode = SwitchMode::PullUp,

--- a/components/devices/src/DeviceInit.cpp
+++ b/components/devices/src/DeviceInit.cpp
@@ -1,20 +1,20 @@
+#include "BootMessage.hpp"
 #include "I2CManager.hpp"
-#include "mqtt/MqttRoot.hpp"
-#include "drivers/SwitchManager.hpp"
-#include "Telemetry.hpp"
-#include "devices/DeviceDefinition.hpp"
-#include "devices/DeviceConfiguration.hpp"
 #include "NvsStore.hpp"
-#include "ShutdownManager.hpp"
 #include "PulseCounter.hpp"
 #include "PwmManager.hpp"
-#include "peripherals/Peripheral.hpp"
+#include "ShutdownManager.hpp"
+#include "Telemetry.hpp"
+#include "devices/DeviceConfiguration.hpp"
+#include "devices/DeviceDefinition.hpp"
+#include "drivers/SwitchManager.hpp"
 #include "functions/Function.hpp"
 #include "functions/FunctionConfigTracker.hpp"
-#include "BootMessage.hpp"
+#include "mqtt/MqttRoot.hpp"
+#include "peripherals/Peripheral.hpp"
 #include <DeviceInit.hpp>
-
 #include <Log.hpp>
+
 #include <memory>
 #include <string>
 #include <utility>

--- a/components/devices/src/DeviceInit.hpp
+++ b/components/devices/src/DeviceInit.hpp
@@ -1,20 +1,18 @@
 #pragma once
 
-#include <cstdint>
-#include <memory>
-#include <string>
-
+#include <BootMessage.hpp>
 #include <NvsStore.hpp>
 #include <ShutdownManager.hpp>
 #include <Telemetry.hpp>
+#include <devices/DeviceConfiguration.hpp>
+#include <devices/DeviceDefinition.hpp>
+#include <functions/Function.hpp>
 #include <mqtt/MqttRoot.hpp>
 #include <peripherals/Peripheral.hpp>
 
-#include <devices/DeviceConfiguration.hpp>
-#include <devices/DeviceDefinition.hpp>
-
-#include <BootMessage.hpp>
-#include <functions/Function.hpp>
+#include <cstdint>
+#include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::devices;
 using namespace cornucopia::ugly_duckling::functions;

--- a/components/devices/src/HeapTrace.hpp
+++ b/components/devices/src/HeapTrace.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #ifdef CONFIG_HEAP_TRACING
-#include <string>
-
 #include <esp_heap_trace.h>
 #include <esp_system.h>
+
+#include <string>
 
 #define NUM_RECORDS 64
 static heap_trace_record_t trace_record[NUM_RECORDS];    // This buffer must be in internal RAM
@@ -24,9 +24,9 @@ public:
 #endif
 
 #ifdef CONFIG_HEAP_TASK_TRACKING
-#include <string>
-
 #include <esp_heap_task_info.h>
+
+#include <string>
 
 #define MAX_TASK_NUM 20     // Max number of per tasks info that it can store
 #define MAX_BLOCK_NUM 20    // Max number of per block info that it can store

--- a/components/devices/src/MqttCommands.cpp
+++ b/components/devices/src/MqttCommands.cpp
@@ -1,19 +1,17 @@
-#include "mqtt/MqttRoot.hpp"
 #include "NvsStore.hpp"
+#include "mqtt/MqttRoot.hpp"
+#include <HttpUpdate.hpp>
 #include <Log.hpp>
 #include <MqttCommands.hpp>
+#include <Restart.hpp>
+
+#include <esp_sleep.h>
 
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <memory>
 #include <string>
-
-#include <esp_sleep.h>
-
-#include <HttpUpdate.hpp>
-
-#include <Restart.hpp>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/devices/src/MqttCommands.hpp
+++ b/components/devices/src/MqttCommands.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <memory>
-
 #include <NvsStore.hpp>
 #include <drivers/LedDriver.hpp>
 #include <mqtt/MqttRoot.hpp>
+
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::mqtt;

--- a/components/devices/src/NetworkConfig.hpp
+++ b/components/devices/src/NetworkConfig.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <algorithm>
-#include <string>
-
 #include <MacAddress.hpp>
 #include <drivers/RtcDriver.hpp>
 #include <mqtt/MqttDriver.hpp>
+
+#include <algorithm>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::mqtt;

--- a/components/devices/src/SyncPublisher.cpp
+++ b/components/devices/src/SyncPublisher.cpp
@@ -8,6 +8,7 @@
 #include "mqtt/MqttRoot.hpp"
 #include <SyncPublisher.hpp>
 #include <UpdateFilter.hpp>
+
 #include <memory>
 #include <optional>
 #include <string>

--- a/components/devices/src/SyncPublisher.hpp
+++ b/components/devices/src/SyncPublisher.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <KernelStatus.hpp>
 #include <Queue.hpp>
 #include <config/ConfigState.hpp>
@@ -8,6 +7,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::functions;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/devices/src/SyncPublisher.hpp
+++ b/components/devices/src/SyncPublisher.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <memory>
-#include <optional>
-
 #include <KernelStatus.hpp>
 #include <Queue.hpp>
 #include <config/ConfigState.hpp>
 #include <functions/Function.hpp>
 #include <mqtt/MqttRoot.hpp>
+
+#include <memory>
+#include <optional>
 
 using namespace cornucopia::ugly_duckling::functions;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/devices/src/TelemetryTask.cpp
+++ b/components/devices/src/TelemetryTask.cpp
@@ -1,19 +1,20 @@
-#include "Watchdog.hpp"
-#include "mqtt/MqttRoot.hpp"
 #include "BatteryManager.hpp"
 #include "PowerManager.hpp"
 #include "Queue.hpp"
-#include "drivers/WiFiDriver.hpp"
-#include "drivers/BleDriver.hpp"
-#include "Telemetry.hpp"
 #include "Task.hpp"
+#include "Telemetry.hpp"
+#include "Watchdog.hpp"
+#include "drivers/BleDriver.hpp"
+#include "drivers/WiFiDriver.hpp"
 #include "mqtt/MqttDriver.hpp"
+#include "mqtt/MqttRoot.hpp"
 #include <TelemetryTask.hpp>
 
 #include <bits/chrono.h>
+#include <esp_heap_caps.h>
+
 #include <chrono>
 #include <cstdint>
-#include <esp_heap_caps.h>
 #include <memory>
 
 using namespace std::chrono;

--- a/components/devices/src/TelemetryTask.hpp
+++ b/components/devices/src/TelemetryTask.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-
 #include <BatteryManager.hpp>
 #include <PowerManager.hpp>
 #include <Queue.hpp>
@@ -11,6 +8,9 @@
 #include <drivers/BleDriver.hpp>
 #include <drivers/WiFiDriver.hpp>
 #include <mqtt/MqttRoot.hpp>
+
+#include <chrono>
+#include <memory>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/devices/src/devices/DeviceDefinition.hpp
+++ b/components/devices/src/devices/DeviceDefinition.hpp
@@ -1,22 +1,12 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-#include <string>
-#include <vector>
-
-#include <Pin.hpp>
-
-#include <ArduinoJson.h>
-
-#include <devices/DeviceConfiguration.hpp>
-
 #include <Log.hpp>
+#include <Pin.hpp>
 #include <PulseCounter.hpp>
 #include <PwmManager.hpp>
+#include <devices/DeviceConfiguration.hpp>
 #include <drivers/BatteryDriver.hpp>
 #include <drivers/LedDriver.hpp>
-
 #include <functions/chicken_door/ChickenDoor.hpp>
 #include <functions/plot_controller/PlotController.hpp>
 #include <peripherals/Peripheral.hpp>
@@ -37,6 +27,13 @@
 #include <peripherals/light_sensor/Bh1750.hpp>
 #include <peripherals/light_sensor/Tsl2591.hpp>
 #include <peripherals/multiplexer/Xl9535.hpp>
+
+#include <ArduinoJson.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
 
 using namespace cornucopia::ugly_duckling::functions;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/devices/src/devices/GenericDevice.hpp
+++ b/components/devices/src/devices/GenericDevice.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
 #include <Pin.hpp>
-#include <drivers/LedDriver.hpp>
-
-#include <peripherals/Peripheral.hpp>
-
 #include <devices/DeviceDefinition.hpp>
+#include <drivers/LedDriver.hpp>
+#include <peripherals/Peripheral.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/devices/src/devices/GenericDevice.hpp
+++ b/components/devices/src/devices/GenericDevice.hpp
@@ -1,9 +1,10 @@
 #pragma once
-
 #include <Pin.hpp>
 #include <devices/DeviceDefinition.hpp>
 #include <drivers/LedDriver.hpp>
 #include <peripherals/Peripheral.hpp>
+
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/devices/src/devices/UglyDucklingMk10.hpp
+++ b/components/devices/src/devices/UglyDucklingMk10.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <MacAddress.hpp>
 #include <Pin.hpp>
 #include <devices/DeviceDefinition.hpp>
@@ -13,6 +12,7 @@
 #include <peripherals/valve/ValveFactory.hpp>
 
 #include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/devices/src/devices/UglyDucklingMk10.hpp
+++ b/components/devices/src/devices/UglyDucklingMk10.hpp
@@ -1,20 +1,18 @@
 #pragma once
 
-#include <memory>
-
 #include <MacAddress.hpp>
 #include <Pin.hpp>
+#include <devices/DeviceDefinition.hpp>
 #include <drivers/Bq27220Driver.hpp>
 #include <drivers/Drv8848Driver.hpp>
 #include <drivers/Ina219Driver.hpp>
 #include <drivers/LedDriver.hpp>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/door/Door.hpp>
 #include <peripherals/environment/SpadefootToadSensor.hpp>
 #include <peripherals/valve/ValveFactory.hpp>
 
-#include <devices/DeviceDefinition.hpp>
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/devices/src/devices/UglyDucklingMk11.hpp
+++ b/components/devices/src/devices/UglyDucklingMk11.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <MacAddress.hpp>
 #include <Pin.hpp>
 #include <devices/DeviceDefinition.hpp>
@@ -14,6 +13,7 @@
 #include <soc/rtc.h>
 
 #include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/devices/src/devices/UglyDucklingMk11.hpp
+++ b/components/devices/src/devices/UglyDucklingMk11.hpp
@@ -1,21 +1,19 @@
 #pragma once
 
-#include <memory>
-
-#include <soc/rtc.h>
-
 #include <MacAddress.hpp>
 #include <Pin.hpp>
+#include <devices/DeviceDefinition.hpp>
 #include <drivers/Bq27220Driver.hpp>
 #include <drivers/Drv8848Driver.hpp>
 #include <drivers/LedDriver.hpp>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/door/Door.hpp>
 #include <peripherals/environment/SpadefootToadSensor.hpp>
 #include <peripherals/valve/ValveFactory.hpp>
 
-#include <devices/DeviceDefinition.hpp>
+#include <soc/rtc.h>
+
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/devices/src/devices/UglyDucklingMk12.hpp
+++ b/components/devices/src/devices/UglyDucklingMk12.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <MacAddress.hpp>
 #include <Pin.hpp>
 #include <devices/DeviceDefinition.hpp>
@@ -14,6 +13,7 @@
 #include <soc/rtc.h>
 
 #include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/devices/src/devices/UglyDucklingMk12.hpp
+++ b/components/devices/src/devices/UglyDucklingMk12.hpp
@@ -1,21 +1,19 @@
 #pragma once
 
-#include <memory>
-
-#include <soc/rtc.h>
-
 #include <MacAddress.hpp>
 #include <Pin.hpp>
+#include <devices/DeviceDefinition.hpp>
 #include <drivers/Bq27220Driver.hpp>
 #include <drivers/BuzzerDriver.hpp>
 #include <drivers/Drv8848Driver.hpp>
 #include <drivers/LedDriver.hpp>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/door/Door.hpp>
 #include <peripherals/valve/ValveFactory.hpp>
 
-#include <devices/DeviceDefinition.hpp>
+#include <soc/rtc.h>
+
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/devices/src/devices/UglyDucklingMk5.hpp
+++ b/components/devices/src/devices/UglyDucklingMk5.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Pin.hpp>
 #include <devices/DeviceDefinition.hpp>
 #include <drivers/BatteryDriver.hpp>
@@ -7,6 +6,9 @@
 #include <drivers/LedDriver.hpp>
 #include <peripherals/door/Door.hpp>
 #include <peripherals/valve/ValveFactory.hpp>
+
+#include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals::door;

--- a/components/devices/src/devices/UglyDucklingMk5.hpp
+++ b/components/devices/src/devices/UglyDucklingMk5.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
 #include <Pin.hpp>
+#include <devices/DeviceDefinition.hpp>
 #include <drivers/BatteryDriver.hpp>
 #include <drivers/Drv8874Driver.hpp>
 #include <drivers/LedDriver.hpp>
-
 #include <peripherals/door/Door.hpp>
 #include <peripherals/valve/ValveFactory.hpp>
-
-#include <devices/DeviceDefinition.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals::door;

--- a/components/devices/src/devices/UglyDucklingMk6.hpp
+++ b/components/devices/src/devices/UglyDucklingMk6.hpp
@@ -1,18 +1,16 @@
 #pragma once
 
-#include <map>
-#include <memory>
-
 #include <Pin.hpp>
+#include <devices/DeviceDefinition.hpp>
 #include <drivers/BatteryDriver.hpp>
 #include <drivers/Drv8833Driver.hpp>
 #include <drivers/LedDriver.hpp>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/door/Door.hpp>
 #include <peripherals/valve/ValveFactory.hpp>
 
-#include <devices/DeviceDefinition.hpp>
+#include <map>
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals::door;
@@ -62,7 +60,6 @@ protected:
         peripheralManager->registerFactory(door::makeFactory(motors));
     }
 
-
     DEFINE_PIN(GPIO_NUM_1, BATTERY)
     DEFINE_PIN(GPIO_NUM_4, STATUS2)
     DEFINE_PIN(GPIO_NUM_5, IOB1, "B1")
@@ -102,7 +99,9 @@ protected:
 // MAC prefix 0x34:0x85:0x18
 class UglyDucklingMk6Rev1 : public UglyDucklingMk6Base {
 public:
-    UglyDucklingMk6Rev1() : UglyDucklingMk6Base(1) {}
+    UglyDucklingMk6Rev1()
+        : UglyDucklingMk6Base(1) {
+    }
 
 protected:
     PinPtr motorNSleepPin() const override {
@@ -113,7 +112,9 @@ protected:
 // MAC prefix 0xec:0xda:0x3b:0x5b
 class UglyDucklingMk6Rev2 : public UglyDucklingMk6Base {
 public:
-    UglyDucklingMk6Rev2() : UglyDucklingMk6Base(2) {}
+    UglyDucklingMk6Rev2()
+        : UglyDucklingMk6Base(2) {
+    }
 
 protected:
     PinPtr motorNSleepPin() const override {
@@ -124,7 +125,9 @@ protected:
 // All other known MK6 MAC ranges
 class UglyDucklingMk6Rev3 : public UglyDucklingMk6Base {
 public:
-    UglyDucklingMk6Rev3() : UglyDucklingMk6Base(3) {}
+    UglyDucklingMk6Rev3()
+        : UglyDucklingMk6Base(3) {
+    }
 
 protected:
     PinPtr motorNSleepPin() const override {

--- a/components/devices/src/devices/UglyDucklingMk6.hpp
+++ b/components/devices/src/devices/UglyDucklingMk6.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Pin.hpp>
 #include <devices/DeviceDefinition.hpp>
 #include <drivers/BatteryDriver.hpp>
@@ -11,6 +10,7 @@
 
 #include <map>
 #include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals::door;

--- a/components/devices/src/devices/UglyDucklingMk7.hpp
+++ b/components/devices/src/devices/UglyDucklingMk7.hpp
@@ -1,15 +1,13 @@
 #pragma once
 
 #include <Pin.hpp>
+#include <devices/DeviceDefinition.hpp>
 #include <drivers/Bq27220Driver.hpp>
 #include <drivers/Drv8833Driver.hpp>
 #include <drivers/LedDriver.hpp>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/door/Door.hpp>
 #include <peripherals/valve/ValveFactory.hpp>
-
-#include <devices/DeviceDefinition.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals::door;

--- a/components/devices/src/devices/UglyDucklingMk7.hpp
+++ b/components/devices/src/devices/UglyDucklingMk7.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Pin.hpp>
 #include <devices/DeviceDefinition.hpp>
 #include <drivers/Bq27220Driver.hpp>
@@ -8,6 +7,9 @@
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/door/Door.hpp>
 #include <peripherals/valve/ValveFactory.hpp>
+
+#include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals::door;

--- a/components/devices/src/devices/UglyDucklingMk8.hpp
+++ b/components/devices/src/devices/UglyDucklingMk8.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <MacAddress.hpp>
 #include <Pin.hpp>
 #include <devices/DeviceDefinition.hpp>
@@ -12,6 +11,7 @@
 #include <peripherals/valve/ValveFactory.hpp>
 
 #include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/devices/src/devices/UglyDucklingMk8.hpp
+++ b/components/devices/src/devices/UglyDucklingMk8.hpp
@@ -1,19 +1,17 @@
 #pragma once
 
-#include <memory>
-
 #include <MacAddress.hpp>
 #include <Pin.hpp>
+#include <devices/DeviceDefinition.hpp>
 #include <drivers/Bq27220Driver.hpp>
 #include <drivers/Drv8848Driver.hpp>
 #include <drivers/Ina219Driver.hpp>
 #include <drivers/LedDriver.hpp>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/door/Door.hpp>
 #include <peripherals/valve/ValveFactory.hpp>
 
-#include <devices/DeviceDefinition.hpp>
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;
@@ -112,7 +110,9 @@ protected:
 // MAC prefix 0x98:0xa3:0x16:0x1a — INA219 omitted due to hardware fault on these units
 class UglyDucklingMk8Rev1 : public UglyDucklingMk8Base {
 public:
-    UglyDucklingMk8Rev1() : UglyDucklingMk8Base(1) {}
+    UglyDucklingMk8Rev1()
+        : UglyDucklingMk8Base(1) {
+    }
 
 protected:
     void registerDeviceSpecificPeripheralFactories(const std::shared_ptr<PeripheralManager>& peripheralManager, const PeripheralServices& services, const std::shared_ptr<DeviceConfiguration>& _deviceConfig) override {
@@ -123,7 +123,10 @@ protected:
 // All other known MK8 MAC ranges — INA219 included
 class UglyDucklingMk8Rev2 : public UglyDucklingMk8Base {
 public:
-    UglyDucklingMk8Rev2() : UglyDucklingMk8Base(2) {}
+    UglyDucklingMk8Rev2()
+        : UglyDucklingMk8Base(2) {
+    }
+
 protected:
     void registerDeviceSpecificPeripheralFactories(const std::shared_ptr<PeripheralManager>& peripheralManager, const PeripheralServices& services, const std::shared_ptr<DeviceConfiguration>& _deviceConfig) override {
         registerMotorAndValves(peripheralManager, services);

--- a/components/devices/src/devices/UglyDucklingMk9.hpp
+++ b/components/devices/src/devices/UglyDucklingMk9.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <MacAddress.hpp>
 #include <Pin.hpp>
 #include <devices/DeviceDefinition.hpp>
@@ -12,6 +11,7 @@
 #include <peripherals/valve/ValveFactory.hpp>
 
 #include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/devices/src/devices/UglyDucklingMk9.hpp
+++ b/components/devices/src/devices/UglyDucklingMk9.hpp
@@ -1,19 +1,17 @@
 #pragma once
 
-#include <memory>
-
 #include <MacAddress.hpp>
 #include <Pin.hpp>
+#include <devices/DeviceDefinition.hpp>
 #include <drivers/Bq27220Driver.hpp>
 #include <drivers/Drv8848Driver.hpp>
 #include <drivers/Ina219Driver.hpp>
 #include <drivers/LedDriver.hpp>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/door/Door.hpp>
 #include <peripherals/valve/ValveFactory.hpp>
 
-#include <devices/DeviceDefinition.hpp>
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/functions/src/functions/Function.hpp
+++ b/components/functions/src/functions/Function.hpp
@@ -5,7 +5,6 @@
 #include <Telemetry.hpp>
 #include <config/ConfigEnvelope.hpp>
 #include <config/StoredConfig.hpp>
-
 #include <functions/FunctionConfigTracker.hpp>
 #include <peripherals/Peripheral.hpp>
 

--- a/components/functions/src/functions/Function.hpp
+++ b/components/functions/src/functions/Function.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Manager.hpp>
 #include <NvsStore.hpp>
 #include <Telemetry.hpp>
@@ -7,6 +6,10 @@
 #include <config/StoredConfig.hpp>
 #include <functions/FunctionConfigTracker.hpp>
 #include <peripherals/Peripheral.hpp>
+
+#include <functional>
+#include <memory>
+#include <string>
 
 using cornucopia::ugly_duckling::kernel::config::ConfigEnvelope;
 using cornucopia::ugly_duckling::kernel::config::StoredConfig;

--- a/components/functions/src/functions/FunctionConfigTracker.hpp
+++ b/components/functions/src/functions/FunctionConfigTracker.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <ArduinoJson.h>
+
 #include <functional>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
-
-#include <ArduinoJson.h>
 
 namespace cornucopia::ugly_duckling::functions {
 

--- a/components/functions/src/functions/ScheduledTransitionLoop.hpp
+++ b/components/functions/src/functions/ScheduledTransitionLoop.hpp
@@ -1,18 +1,17 @@
 #pragma once
 
-#include <chrono>
-#include <functional>
-#include <memory>
-#include <string>
-
 #include <Log.hpp>
 #include <Queue.hpp>
 #include <Task.hpp>
 #include <Telemetry.hpp>
 #include <Time.hpp>
-
 #include <peripherals/api/TargetState.hpp>
 #include <scheduling/IScheduler.hpp>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
 
 using namespace std::chrono_literals;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/functions/src/functions/chicken_door/ChickenDoor.hpp
+++ b/components/functions/src/functions/chicken_door/ChickenDoor.hpp
@@ -1,19 +1,18 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-#include <utility>
-
 #include <Named.hpp>
 #include <config/Configuration.hpp>
 #include <functions/Function.hpp>
 #include <functions/ScheduledTransitionLoop.hpp>
-
 #include <peripherals/api/IDoor.hpp>
 #include <scheduling/CompositeScheduler.hpp>
 #include <scheduling/DelayScheduler.hpp>
 #include <scheduling/LightSensorScheduler.hpp>
 #include <scheduling/OverrideScheduler.hpp>
+
+#include <chrono>
+#include <memory>
+#include <utility>
 
 using namespace cornucopia::ugly_duckling::peripherals::api;
 using namespace cornucopia::ugly_duckling::utils::scheduling;

--- a/components/functions/src/functions/chicken_door/ChickenDoor.hpp
+++ b/components/functions/src/functions/chicken_door/ChickenDoor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Named.hpp>
 #include <config/Configuration.hpp>
 #include <functions/Function.hpp>
@@ -12,6 +11,7 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
 #include <utility>
 
 using namespace cornucopia::ugly_duckling::peripherals::api;

--- a/components/functions/src/functions/plot_controller/PlotController.hpp
+++ b/components/functions/src/functions/plot_controller/PlotController.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-#include <utility>
-
 #include <Log.hpp>
 #include <Named.hpp>
 #include <config/Configuration.hpp>
@@ -18,6 +14,10 @@
 #include <scheduling/OverrideScheduler.hpp>
 #include <scheduling/TimeBasedScheduler.hpp>
 #include <utils/Chrono.hpp>
+
+#include <chrono>
+#include <memory>
+#include <utility>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::kernel::mqtt;

--- a/components/functions/src/functions/plot_controller/PlotController.hpp
+++ b/components/functions/src/functions/plot_controller/PlotController.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Log.hpp>
 #include <Named.hpp>
 #include <config/Configuration.hpp>
@@ -17,6 +16,7 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/functions/test/FunctionConfigTrackerTest.cpp
+++ b/components/functions/test/FunctionConfigTrackerTest.cpp
@@ -1,10 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_exception.hpp>
+#include <functions/FunctionConfigTracker.hpp>
 
 #include <string>
-
-#include <functions/FunctionConfigTracker.hpp>
 
 using namespace cornucopia::ugly_duckling::functions;
 
@@ -15,8 +14,8 @@ TEST_CASE("manifest is empty before anything is recorded") {
 
 TEST_CASE("manifest reports fingerprints and requestedAt recorded at creation") {
     FunctionConfigTracker tracker;
-    tracker.record("valve1", [](JsonObjectConst) {}, "fp-1", "2026-07-30T12:00:00Z");
-    tracker.record("valve2", [](JsonObjectConst) {}, "fp-2", "2026-07-30T13:00:00Z");
+    tracker.record("valve1", [](JsonObjectConst) { }, "fp-1", "2026-07-30T12:00:00Z");
+    tracker.record("valve2", [](JsonObjectConst) { }, "fp-2", "2026-07-30T13:00:00Z");
 
     auto manifest = tracker.manifest();
     REQUIRE(manifest.size() == 2);
@@ -29,10 +28,7 @@ TEST_CASE("manifest reports fingerprints and requestedAt recorded at creation") 
 TEST_CASE("apply invokes the configureFn with the given data") {
     FunctionConfigTracker tracker;
     JsonObjectConst received;
-    tracker.record("valve1", [&](JsonObjectConst data) {
-        received = data;
-    },
-        "fp-1", "2026-07-30T12:00:00Z");
+    tracker.record("valve1", [&](JsonObjectConst data) { received = data; }, "fp-1", "2026-07-30T12:00:00Z");
 
     JsonDocument body;
     body["openDuration"] = 30;
@@ -43,7 +39,7 @@ TEST_CASE("apply invokes the configureFn with the given data") {
 
 TEST_CASE("apply records the new fingerprint and requestedAt only after a successful configureFn") {
     FunctionConfigTracker tracker;
-    tracker.record("valve1", [](JsonObjectConst) {}, "fp-1", "2026-07-30T12:00:00Z");
+    tracker.record("valve1", [](JsonObjectConst) { }, "fp-1", "2026-07-30T12:00:00Z");
 
     JsonDocument body;
     tracker.apply("valve1", body.as<JsonObjectConst>(), "fp-2", "2026-07-30T13:00:00Z");
@@ -55,10 +51,7 @@ TEST_CASE("apply records the new fingerprint and requestedAt only after a succes
 
 TEST_CASE("apply does not update the fingerprint or requestedAt when configureFn throws") {
     FunctionConfigTracker tracker;
-    tracker.record("valve1", [](JsonObjectConst) {
-        throw std::runtime_error("bad config");
-    },
-        "fp-1", "2026-07-30T12:00:00Z");
+    tracker.record("valve1", [](JsonObjectConst) { throw std::runtime_error("bad config"); }, "fp-1", "2026-07-30T12:00:00Z");
 
     JsonDocument body;
     REQUIRE_THROWS_WITH(tracker.apply("valve1", body.as<JsonObjectConst>(), "fp-2", "2026-07-30T13:00:00Z"), "bad config");
@@ -101,9 +94,9 @@ TEST_CASE("writeSyncManifest writes fingerprint and requestedAt per function, ke
     JsonDocument doc;
     auto configurations = doc.to<JsonObject>();
     writeSyncManifest(configurations, {
-                                           { "valve1", { .fingerprint = "fp-1", .requestedAt = "2026-07-30T12:00:00Z" } },
-                                           { "door1", { .fingerprint = "fp-2", .requestedAt = "2026-07-30T13:00:00Z" } },
-                                       });
+                                          { "valve1", { .fingerprint = "fp-1", .requestedAt = "2026-07-30T12:00:00Z" } },
+                                          { "door1", { .fingerprint = "fp-2", .requestedAt = "2026-07-30T13:00:00Z" } },
+                                      });
 
     REQUIRE(configurations.size() == 2);
     REQUIRE(configurations["valve1"]["fingerprint"].as<std::string>() == "fp-1");

--- a/components/kernel/src/BatteryManager.hpp
+++ b/components/kernel/src/BatteryManager.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <memory>
-
-#include <esp_sleep.h>
-
 #include <MovingAverage.hpp>
 #include <ShutdownManager.hpp>
 #include <Task.hpp>
 #include <Telemetry.hpp>
 #include <drivers/BatteryDriver.hpp>
+
+#include <esp_sleep.h>
+
+#include <memory>
 #include <utility>
 
 using namespace cornucopia::ugly_duckling::kernel::drivers;
@@ -63,7 +63,7 @@ public:
 
 private:
     void checkBatteryVoltage(Task& task) {
-                auto currentVoltage = battery->getVoltage();
+        auto currentVoltage = battery->getVoltage();
         batteryVoltage.record(currentVoltage);
         auto voltage = batteryVoltage.getAverage();
 

--- a/components/kernel/src/Console.hpp
+++ b/components/kernel/src/Console.hpp
@@ -1,8 +1,9 @@
 #pragma once
-
 #include <Log.hpp>
 #include <Queue.hpp>
 
+#include <memory>
+#include <string>
 #include <utility>
 
 namespace cornucopia::ugly_duckling::kernel {

--- a/components/kernel/src/Console.hpp
+++ b/components/kernel/src/Console.hpp
@@ -2,6 +2,7 @@
 
 #include <Log.hpp>
 #include <Queue.hpp>
+
 #include <utility>
 
 namespace cornucopia::ugly_duckling::kernel {

--- a/components/kernel/src/CrashManager.hpp
+++ b/components/kernel/src/CrashManager.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <optional>
-#include <string>
+#include <Strings.hpp>
 
+#include <ArduinoJson.h>
 #include <esp_core_dump.h>
 #include <mbedtls/base64.h>
 
-#include <ArduinoJson.h>
-
-#include <Strings.hpp>
+#include <optional>
+#include <string>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/DebugConsole.hpp
+++ b/components/kernel/src/DebugConsole.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <chrono>
-
-#include <esp_private/esp_clk.h>
-
 #include <BatteryManager.hpp>
 #include <Strings.hpp>
 #include <drivers/BleDriver.hpp>
 #include <drivers/RtcDriver.hpp>
 #include <drivers/WiFiDriver.hpp>
+
+#include <esp_private/esp_clk.h>
+
+#include <chrono>
 
 using namespace std::chrono;
 

--- a/components/kernel/src/DebugConsole.hpp
+++ b/components/kernel/src/DebugConsole.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <BatteryManager.hpp>
 #include <Strings.hpp>
 #include <drivers/BleDriver.hpp>
@@ -9,6 +8,8 @@
 #include <esp_private/esp_clk.h>
 
 #include <chrono>
+#include <memory>
+#include <string>
 
 using namespace std::chrono;
 

--- a/components/kernel/src/EspException.hpp
+++ b/components/kernel/src/EspException.hpp
@@ -2,7 +2,7 @@
 
 #include <esp_err.h>
 
-#include <exception>
+#include <stdexcept>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/EspException.hpp
+++ b/components/kernel/src/EspException.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <esp_err.h>
+
 #include <exception>
 
 namespace cornucopia::ugly_duckling::kernel {

--- a/components/kernel/src/FirmwareRollback.hpp
+++ b/components/kernel/src/FirmwareRollback.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <optional>
-#include <string>
+#include <Log.hpp>
+#include <config/ConfigState.hpp>
 
 #include <esp_ota_ops.h>
 
-#include <Log.hpp>
-#include <config/ConfigState.hpp>
+#include <optional>
+#include <string>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/FirmwareUpdateDecision.hpp
+++ b/components/kernel/src/FirmwareUpdateDecision.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <ArduinoJson.h>
+
 #include <optional>
 #include <string>
-
-#include <ArduinoJson.h>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/HardwareVersion.hpp
+++ b/components/kernel/src/HardwareVersion.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <cstdint>
-#include <cstring>
-#include <optional>
+#include <Log.hpp>
 
 #include <esp_efuse.h>
 #include <esp_efuse_table.h>
 
-#include <Log.hpp>
+#include <cstdint>
+#include <cstring>
+#include <optional>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/HttpUpdate.hpp
+++ b/components/kernel/src/HttpUpdate.hpp
@@ -1,20 +1,19 @@
 #pragma once
 
-#include <optional>
-#include <string>
-
-#include <ArduinoJson.h>
-
-#include <esp_crt_bundle.h>
-#include <esp_http_client.h>
-#include <esp_https_ota.h>
-
 #include <Log.hpp>
 #include <NvsStore.hpp>
 #include <Restart.hpp>
 #include <Watchdog.hpp>
 #include <config/ConfigState.hpp>
 #include <drivers/WiFiDriver.hpp>
+
+#include <ArduinoJson.h>
+#include <esp_crt_bundle.h>
+#include <esp_http_client.h>
+#include <esp_https_ota.h>
+
+#include <optional>
+#include <string>
 #include <utility>
 
 namespace cornucopia::ugly_duckling::kernel {

--- a/components/kernel/src/HttpUpdate.hpp
+++ b/components/kernel/src/HttpUpdate.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Log.hpp>
 #include <NvsStore.hpp>
 #include <Restart.hpp>
@@ -12,6 +11,7 @@
 #include <esp_http_client.h>
 #include <esp_https_ota.h>
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>

--- a/components/kernel/src/I2CManager.hpp
+++ b/components/kernel/src/I2CManager.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <exception>
-#include <memory>
-#include <mutex>
-#include <vector>
-
-#include <driver/i2c_master.h>
-
-#include <i2cdev.h>
 #include <EspException.hpp>
 #include <Pin.hpp>
 #include <Strings.hpp>
+
+#include <driver/i2c_master.h>
+#include <i2cdev.h>
+
+#include <exception>
+#include <memory>
+#include <mutex>
 #include <utility>
+#include <vector>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/I2CManager.hpp
+++ b/components/kernel/src/I2CManager.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <EspException.hpp>
 #include <Pin.hpp>
 #include <Strings.hpp>
@@ -10,6 +9,8 @@
 #include <exception>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/components/kernel/src/KernelStatus.hpp
+++ b/components/kernel/src/KernelStatus.hpp
@@ -1,16 +1,5 @@
 #pragma once
 
-#include <chrono>
-#include <concepts>
-#include <functional>
-#include <optional>
-
-#include <esp_system.h>
-
-#include <nvs_flash.h>
-
-#include <freertos/FreeRTOS.h>    // NOLINT(misc-header-include-cycle)
-
 #include <I2CManager.hpp>
 #include <PowerManager.hpp>
 #include <StateManager.hpp>
@@ -19,6 +8,15 @@
 #include <drivers/SwitchManager.hpp>
 #include <drivers/WiFiDriver.hpp>
 #include <mqtt/MqttDriver.hpp>
+
+#include <esp_system.h>
+#include <freertos/FreeRTOS.h>    // NOLINT(misc-header-include-cycle)
+#include <nvs_flash.h>
+
+#include <chrono>
+#include <concepts>
+#include <functional>
+#include <optional>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/kernel/src/KernelStatus.hpp
+++ b/components/kernel/src/KernelStatus.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <I2CManager.hpp>
 #include <PowerManager.hpp>
 #include <StateManager.hpp>
@@ -16,6 +15,7 @@
 #include <chrono>
 #include <concepts>
 #include <functional>
+#include <memory>
 #include <optional>
 
 using namespace std::chrono;

--- a/components/kernel/src/Log.hpp
+++ b/components/kernel/src/Log.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
+#include <esp_log.h>
 #include <string.h>
 
 #include <string>
-
-#include <esp_log.h>
 
 namespace cornucopia::ugly_duckling::kernel {
 
@@ -52,17 +51,17 @@ inline bool loggingTagInList(const char* tag, const char* list) {
 }
 
 // LOGGING_TAG(varName, "tagname")
-#define LOGGING_TAG(varName, name)                              \
+#define LOGGING_TAG(varName, name)                        \
     inline constexpr const char* varName = "ud:" name;    \
-    struct varName##_LoggerInit {                              \
-        varName##_LoggerInit() {                               \
+    struct varName##_LoggerInit {                         \
+        varName##_LoggerInit() {                          \
             esp_log_level_t lvl = UD_LOG_LEVEL;           \
             if (loggingTagInList(name, UD_LOG_VERBOSE)) { \
-                lvl = ESP_LOG_VERBOSE;                         \
-            }                                                  \
-            esp_log_level_set(varName, lvl);                   \
-        }                                                      \
-    };                                                         \
+                lvl = ESP_LOG_VERBOSE;                    \
+            }                                             \
+            esp_log_level_set(varName, lvl);              \
+        }                                                 \
+    };                                                    \
     inline const varName##_LoggerInit varName##_logger_init;
 
 LOGGING_TAG(GLOBAL, "global")

--- a/components/kernel/src/LogJson.hpp
+++ b/components/kernel/src/LogJson.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <ArduinoJson.h>
 #include <Log.hpp>
+
+#include <ArduinoJson.h>
 
 namespace ArduinoJson {
 

--- a/components/kernel/src/MacAddress.hpp
+++ b/components/kernel/src/MacAddress.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <EspException.hpp>
 
 #include <esp_mac.h>
 
-#include <EspException.hpp>
+#include <string>
+#include <vector>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/Manager.hpp
+++ b/components/kernel/src/Manager.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <Log.hpp>
+#include <config/Configuration.hpp>
+
 #include <concepts>
 #include <functional>
 #include <map>
@@ -8,8 +11,6 @@
 #include <string>
 #include <type_traits>
 #include <unordered_map>
-#include <Log.hpp>
-#include <config/Configuration.hpp>
 
 namespace cornucopia::ugly_duckling::kernel {
 
@@ -48,7 +49,8 @@ public:
             h.entries.push_back({ &TypeTokenVar<Impl>, std::static_pointer_cast<void>(impl) });
         } else {
             (h.entries.push_back({ &TypeTokenVar<Interfaces>,
-                std::static_pointer_cast<void>(std::static_pointer_cast<Interfaces>(impl)) }), ...);
+                 std::static_pointer_cast<void>(std::static_pointer_cast<Interfaces>(impl)) }),
+                ...);
         }
 
         // If implementation supports shutdown, register it with the manager now

--- a/components/kernel/src/Manager.hpp
+++ b/components/kernel/src/Manager.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Log.hpp>
 #include <config/Configuration.hpp>
 
@@ -8,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <unordered_map>

--- a/components/kernel/src/MovingAverage.hpp
+++ b/components/kernel/src/MovingAverage.hpp
@@ -5,7 +5,7 @@
 namespace cornucopia::ugly_duckling::kernel {
 
 template <typename M, typename T = M>
-requires std::is_arithmetic_v<M> && std::is_arithmetic_v<T>
+    requires std::is_arithmetic_v<M> && std::is_arithmetic_v<T>
 class MovingAverage {
 public:
     MovingAverage(std::size_t maxMeasurements)
@@ -36,8 +36,8 @@ public:
 private:
     const std::size_t maxMeasurements;
     std::vector<M> measurements;
-    std::size_t currentIndex{0};
-    std::size_t count{0};
+    std::size_t currentIndex { 0 };
+    std::size_t count { 0 };
     T sum;
     T average;
 };

--- a/components/kernel/src/Named.hpp
+++ b/components/kernel/src/Named.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/NvsStore.hpp
+++ b/components/kernel/src/NvsStore.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
-#include <functional>
-#include <string>
-#include <vector>
+#include <Log.hpp>
 
+#include <ArduinoJson.h>
 #include <nvs.h>
 #include <nvs_flash.h>
 
-#include <ArduinoJson.h>
-
-#include <Log.hpp>
+#include <functional>
+#include <string>
+#include <vector>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/Pin.cpp
+++ b/components/kernel/src/Pin.cpp
@@ -1,11 +1,11 @@
 #include "Pin.hpp"
 
+#include <esp_adc/adc_oneshot.h>
+#include <soc/gpio_num.h>
+
 #include <map>
 #include <string>
 #include <vector>
-
-#include <esp_adc/adc_oneshot.h>
-#include <soc/gpio_num.h>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/Pin.hpp
+++ b/components/kernel/src/Pin.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <EspException.hpp>
 #include <Log.hpp>
 
@@ -15,6 +14,8 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/components/kernel/src/Pin.hpp
+++ b/components/kernel/src/Pin.hpp
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <exception>
-#include <map>
-#include <memory>
-#include <optional>
-#include <utility>
-#include <vector>
+#include <EspException.hpp>
+#include <Log.hpp>
 
+#include <ArduinoJson.h>
 #include <driver/gpio.h>
 #include <driver/gpio_filter.h>
 #include <esp_adc/adc_cali.h>
@@ -14,10 +11,12 @@
 #include <esp_adc/adc_oneshot.h>
 #include <hal/adc_types.h>
 
-#include <ArduinoJson.h>
-
-#include <EspException.hpp>
-#include <Log.hpp>
+#include <exception>
+#include <map>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
 
 namespace cornucopia::ugly_duckling::kernel {
 
@@ -323,7 +322,6 @@ private:
     adc_oneshot_unit_handle_t handle;
     adc_cali_handle_t caliHandle = nullptr;
 };
-
 
 }    // namespace cornucopia::ugly_duckling::kernel
 

--- a/components/kernel/src/PowerManager.hpp
+++ b/components/kernel/src/PowerManager.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <array>
-#include <chrono>
-
-#include <esp_pm.h>
-#include <esp_sleep.h>
-#include <esp_timer.h>
-
 #include <EspException.hpp>
 #include <Log.hpp>
 #include <Queue.hpp>
 #include <Task.hpp>
 #include <Telemetry.hpp>
+
+#include <esp_pm.h>
+#include <esp_sleep.h>
+#include <esp_timer.h>
+
+#include <array>
+#include <chrono>
 
 #if defined(CONFIG_IDF_TARGET_ESP32S2)
 // Apparently on ESP32S2 things start to break down if we go below 80 MHz
@@ -198,10 +198,9 @@ private:
     int lightSleepCount = 0;
 #ifdef UD_PM_DIAGNOSTICS
     // Per-wakeup-cause tally, indexed by esp_sleep_wakeup_cause_t bit position
-    std::array<unsigned long, 32> wakeupCauseCounts = { };
+    std::array<unsigned long, 32> wakeupCauseCounts = {};
 #endif
 #endif
 };
-
 
 }    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/PowerManager.hpp
+++ b/components/kernel/src/PowerManager.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <EspException.hpp>
 #include <Log.hpp>
 #include <Queue.hpp>
@@ -12,6 +11,7 @@
 
 #include <array>
 #include <chrono>
+#include <string>
 
 #if defined(CONFIG_IDF_TARGET_ESP32S2)
 // Apparently on ESP32S2 things start to break down if we go below 80 MHz

--- a/components/kernel/src/PulseCounter.cpp
+++ b/components/kernel/src/PulseCounter.cpp
@@ -1,5 +1,13 @@
 #include "PulseCounter.hpp"
 
+#include "Pin.hpp"
+
+#include <driver/gpio.h>
+#include <esp_err.h>
+#include <esp_pm.h>
+#include <freertos/task.h>
+#include <hal/rtc_io_types.h>
+
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
@@ -7,27 +15,19 @@
 #include <stdexcept>
 #include <utility>
 
-#include <freertos/task.h>
-
-#include <driver/gpio.h>
-#include <esp_err.h>
-#include <esp_pm.h>
-#include <hal/rtc_io_types.h>
-
-#include "Pin.hpp"
-
 #ifdef CONFIG_ULP_COPROC_ENABLED
 #include <driver/rtc_io.h>
 #if defined(CONFIG_ULP_COPROC_TYPE_RISCV)
 #include <ulp_common.h>
 #include <ulp_riscv.h>
 #ifdef UD_DEBUG
-#include <chrono>
+#include <Task.hpp>
+
 #include <soc/rtc_cntl_reg.h>
 #include <soc/sens_reg.h>
 #include <soc/soc.h>
 
-#include <Task.hpp>
+#include <chrono>
 
 using namespace std::chrono_literals;
 #endif
@@ -39,8 +39,8 @@ using namespace std::chrono_literals;
 // channel_count → ulp_channel_count, gpio_num → ulp_gpio_num, etc.
 #include "ulp_pulse_counter.h"
 // Embedded ULP binary produced by CMake.
-extern const uint8_t ulp_pulse_counter_bin_start[] asm("_binary_ulp_pulse_counter_bin_start"); // NOLINT(hicpp-no-assembler)
-extern const uint8_t ulp_pulse_counter_bin_end[]   asm("_binary_ulp_pulse_counter_bin_end");   // NOLINT(hicpp-no-assembler)
+extern const uint8_t ulp_pulse_counter_bin_start[] asm("_binary_ulp_pulse_counter_bin_start");    // NOLINT(hicpp-no-assembler)
+extern const uint8_t ulp_pulse_counter_bin_end[] asm("_binary_ulp_pulse_counter_bin_end");        // NOLINT(hicpp-no-assembler)
 #endif
 
 #include <EspException.hpp>
@@ -181,7 +181,7 @@ void PulseCounterManager::start() {
 
     ulp_channel_count = ulpNextChannel;
     for (uint32_t i = 0; i < ulpNextChannel; i++) {
-        ulp_gpio_num[i]    = ulpChannelConfigs[i].gpioNum;
+        ulp_gpio_num[i] = ulpChannelConfigs[i].gpioNum;
         ulp_debounce_us[i] = ulpChannelConfigs[i].debounceUs;
         ulp_pulse_count[i] = 0;
     }
@@ -207,7 +207,7 @@ void PulseCounterManager::start() {
 #elif defined(CONFIG_ULP_COPROC_TYPE_LP_CORE)
     ulp_lp_core_cfg_t cfg = {
         .wakeup_source = ULP_LP_CORE_WAKEUP_SOURCE_HP_CPU,
-        .lp_timer_sleep_duration_us = 0, // Not used with HP CPU wakeup source
+        .lp_timer_sleep_duration_us = 0,    // Not used with HP CPU wakeup source
     };
     ESP_ERROR_THROW(ulp_lp_core_run(&cfg));
 #endif

--- a/components/kernel/src/PulseCounter.hpp
+++ b/components/kernel/src/PulseCounter.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <atomic>
-#include <chrono>
-#include <memory>
-#include <vector>
-
-#include <driver/gpio.h>
-#include <esp_sleep.h>
-
 #include <EspException.hpp>
 #include <Log.hpp>
 #include <Pin.hpp>
 #include <Queue.hpp>
+
+#include <driver/gpio.h>
+#include <esp_sleep.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <vector>
 
 using namespace std::chrono;
 

--- a/components/kernel/src/PwmManager.hpp
+++ b/components/kernel/src/PwmManager.hpp
@@ -1,8 +1,9 @@
 #pragma once
-
 #include <driver/ledc.h>
 
 #include <list>
+#include <stdexcept>
+#include <string>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/PwmManager.hpp
+++ b/components/kernel/src/PwmManager.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <list>
-
 #include <driver/ledc.h>
+
+#include <list>
 
 namespace cornucopia::ugly_duckling::kernel {
 
@@ -62,7 +62,7 @@ public:
             .gpio_num = pin->getGpio(),
             .speed_mode = timer.speedMode,
             .channel = channel,
-            .intr_type = {}, // NOLINT(clang-diagnostic-deprecated-declarations)
+            .intr_type = {},    // NOLINT(clang-diagnostic-deprecated-declarations)
             .timer_sel = timer.timerNum,
             .duty = 0,    // Set duty to 0%
             .hpoint = 0,

--- a/components/kernel/src/Queue.hpp
+++ b/components/kernel/src/Queue.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Time.hpp>
 
 #include <freertos/FreeRTOS.h>    // NOLINT(misc-header-include-cycle)
@@ -8,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/kernel/src/Queue.hpp
+++ b/components/kernel/src/Queue.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
+#include <Time.hpp>
+
+#include <freertos/FreeRTOS.h>    // NOLINT(misc-header-include-cycle)
+
 #include <chrono>
 #include <functional>
 #include <memory>
 #include <optional>
-
-#include <freertos/FreeRTOS.h>    // NOLINT(misc-header-include-cycle)
-
-#include <Time.hpp>
 #include <utility>
 
 using namespace std::chrono;
@@ -57,7 +57,8 @@ public:
         while (!std::apply([this](auto&&... unpackedArgs) {
             // Note: without 'this->' Clang Tidy complains about unnecessarily captured 'this'
             return this->offerIn(ticks::max(), std::forward<decltype(unpackedArgs)>(unpackedArgs)...);
-        }, innerArgs)) { }
+        },
+            innerArgs)) { }
     }
 
     template <typename... Args>
@@ -225,6 +226,5 @@ public:
         xQueueReset(getQueueHandle());
     }
 };
-
 
 }    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Restart.hpp
+++ b/components/kernel/src/Restart.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <cstdio>
+#include <Task.hpp>
 
 #include <esp_system.h>
 
-#include <Task.hpp>
+#include <cstdio>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/ShutdownManager.hpp
+++ b/components/kernel/src/ShutdownManager.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <Task.hpp>
+
 #include <functional>
 #include <vector>
-
-#include <Task.hpp>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/State.cpp
+++ b/components/kernel/src/State.cpp
@@ -1,4 +1,5 @@
 #include "State.hpp"
+
 #include "freertos/idf_additions.h"
 
 namespace cornucopia::ugly_duckling::kernel {

--- a/components/kernel/src/State.hpp
+++ b/components/kernel/src/State.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <chrono>
+#include <Time.hpp>
 
 #include <freertos/FreeRTOS.h>        // NOLINT(misc-header-include-cycle)
 #include <freertos/event_groups.h>    // NOLINT(misc-header-include-cycle)
 
-#include <Time.hpp>
+#include <chrono>
 
 using namespace std::chrono;
 

--- a/components/kernel/src/State.hpp
+++ b/components/kernel/src/State.hpp
@@ -1,11 +1,11 @@
 #pragma once
-
 #include <Time.hpp>
 
 #include <freertos/FreeRTOS.h>        // NOLINT(misc-header-include-cycle)
 #include <freertos/event_groups.h>    // NOLINT(misc-header-include-cycle)
 
 #include <chrono>
+#include <string>
 
 using namespace std::chrono;
 

--- a/components/kernel/src/StateManager.hpp
+++ b/components/kernel/src/StateManager.hpp
@@ -1,7 +1,8 @@
 #pragma once
-
 #include <State.hpp>
 
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace cornucopia::ugly_duckling::kernel {

--- a/components/kernel/src/StateManager.hpp
+++ b/components/kernel/src/StateManager.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <vector>
-
 #include <State.hpp>
+
+#include <vector>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/Strings.hpp
+++ b/components/kernel/src/Strings.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+
 #include <string>
 
 namespace cornucopia::ugly_duckling::kernel {

--- a/components/kernel/src/Task.hpp
+++ b/components/kernel/src/Task.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <chrono>
-#include <functional>
+#include <Log.hpp>
+#include <Time.hpp>
 
 #include <freertos/FreeRTOS.h>    // NOLINT(misc-header-include-cycle)
 #include <freertos/task.h>        // NOLINT(misc-header-include-cycle)
 
-#include <Log.hpp>
-#include <Time.hpp>
+#include <chrono>
+#include <functional>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/kernel/src/Task.hpp
+++ b/components/kernel/src/Task.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Log.hpp>
 #include <Time.hpp>
 
@@ -8,6 +7,7 @@
 
 #include <chrono>
 #include <functional>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/kernel/src/Telemetry.hpp
+++ b/components/kernel/src/Telemetry.hpp
@@ -1,11 +1,12 @@
 #pragma once
-
 #include <Log.hpp>
 #include <Queue.hpp>
 
 #include <ArduinoJson.h>
 
+#include <functional>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/components/kernel/src/Telemetry.hpp
+++ b/components/kernel/src/Telemetry.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <memory>
-#include <utility>
-#include <vector>
+#include <Log.hpp>
+#include <Queue.hpp>
 
 #include <ArduinoJson.h>
 
-#include <Log.hpp>
-#include <Queue.hpp>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace cornucopia::ugly_duckling::kernel {
 
@@ -47,7 +47,8 @@ private:
 class TelemetryPublisher {
 public:
     TelemetryPublisher(const std::shared_ptr<CopyQueue<bool>>& telemetryPublishQueue)
-        : telemetryPublishQueue(telemetryPublishQueue) {}
+        : telemetryPublishQueue(telemetryPublishQueue) {
+    }
 
     void requestTelemetryPublishing() {
         telemetryPublishQueue->overwrite(true);

--- a/components/kernel/src/Time.hpp
+++ b/components/kernel/src/Time.hpp
@@ -18,4 +18,4 @@ inline static ticks clampTicks(std::chrono::milliseconds duration) {
     return std::chrono::duration_cast<ticks>(duration);
 }
 
-} // namespace cornucopia::ugly_duckling::kernel
+}    // namespace cornucopia::ugly_duckling::kernel

--- a/components/kernel/src/Time.hpp
+++ b/components/kernel/src/Time.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <freertos/FreeRTOS.h>    // NOLINT(misc-header-include-cycle) — for configTICK_RATE_HZ
+
 #include <chrono>
 
 using namespace std::chrono_literals;

--- a/components/kernel/src/UpdateFilter.hpp
+++ b/components/kernel/src/UpdateFilter.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
+#include <config/ConfigEnvelope.hpp>
+
+#include <ArduinoJson.h>
+
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <ArduinoJson.h>
-
-#include <config/ConfigEnvelope.hpp>
 
 namespace cornucopia::ugly_duckling::kernel {
 

--- a/components/kernel/src/Watchdog.hpp
+++ b/components/kernel/src/Watchdog.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <chrono>
-#include <functional>
+#include <Log.hpp>
 
 #include <esp_check.h>
 #include <esp_system.h>
 #include <esp_timer.h>
 
-#include <Log.hpp>
+#include <chrono>
+#include <functional>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/kernel/src/Watchdog.hpp
+++ b/components/kernel/src/Watchdog.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Log.hpp>
 
 #include <esp_check.h>
@@ -8,6 +7,7 @@
 
 #include <chrono>
 #include <functional>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/kernel/src/config/ConfigBootPlan.hpp
+++ b/components/kernel/src/config/ConfigBootPlan.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <optional>
-
 #include "ConfigState.hpp"
+
+#include <optional>
 
 namespace cornucopia::ugly_duckling::kernel::config {
 

--- a/components/kernel/src/config/ConfigEnvelope.hpp
+++ b/components/kernel/src/config/ConfigEnvelope.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
-
 #include <ArduinoJson.h>
+
+#include <string>
 
 namespace cornucopia::ugly_duckling::kernel::config {
 

--- a/components/kernel/src/config/ConfigStaging.hpp
+++ b/components/kernel/src/config/ConfigStaging.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
+#include "ConfigEnvelope.hpp"
+#include "ConfigState.hpp"
+#include <UpdateFilter.hpp>
+
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include "ConfigEnvelope.hpp"
-#include "ConfigState.hpp"
-#include <UpdateFilter.hpp>
 
 namespace cornucopia::ugly_duckling::kernel::config {
 

--- a/components/kernel/src/config/ConfigState.hpp
+++ b/components/kernel/src/config/ConfigState.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <ArduinoJson.h>
+
 #include <cstdint>
 #include <cstring>
 #include <optional>
 #include <string>
-
-#include <ArduinoJson.h>
 
 namespace cornucopia::ugly_duckling::kernel::config {
 
@@ -14,7 +14,10 @@ namespace cornucopia::ugly_duckling::kernel::config {
  * device holds in NVS at any time (docs/Configuration.md, "Storage: envelopes and slots").
  * `config-state` points `confirmed` (and, while staging, `requested`) at one of these.
  */
-enum class ConfigSlot : std::uint8_t { A, B };
+enum class ConfigSlot : std::uint8_t {
+    A,
+    B
+};
 
 inline std::string toString(ConfigSlot slot) {
     return slot == ConfigSlot::B ? "b" : "a";
@@ -29,7 +32,11 @@ inline ConfigSlot otherSlot(ConfigSlot slot) {
  * (docs/Configuration.md, "Storage: envelopes and slots" and "The confirmed/requested state
  * machine").
  */
-enum class RequestedConfigStatus : std::uint8_t { Pending, Attempted, Rejected };
+enum class RequestedConfigStatus : std::uint8_t {
+    Pending,
+    Attempted,
+    Rejected
+};
 
 /**
  * @brief The `google.rpc.Code` subset the firmware can emit (docs/Configuration.md,

--- a/components/kernel/src/config/ConfigStateStore.hpp
+++ b/components/kernel/src/config/ConfigStateStore.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <memory>
-#include <utility>
+#include "ConfigState.hpp"
+#include <Log.hpp>
+#include <NvsStore.hpp>
 
 #include <ArduinoJson.h>
 
-#include <Log.hpp>
-
-#include "ConfigState.hpp"
-#include <NvsStore.hpp>
+#include <memory>
+#include <utility>
 
 namespace cornucopia::ugly_duckling::kernel::config {
 

--- a/components/kernel/src/config/Configuration.hpp
+++ b/components/kernel/src/config/Configuration.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ArduinoJson.h>
+
 #include <chrono>
 #include <concepts>
 #include <functional>
@@ -7,8 +9,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#include <ArduinoJson.h>
 
 using std::ref;
 using std::reference_wrapper;

--- a/components/kernel/src/config/Configuration.hpp
+++ b/components/kernel/src/config/Configuration.hpp
@@ -1,11 +1,11 @@
 #pragma once
-
 #include <ArduinoJson.h>
 
 #include <chrono>
 #include <concepts>
 #include <functional>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/components/kernel/src/config/NvsConfiguration.hpp
+++ b/components/kernel/src/config/NvsConfiguration.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <functional>
-#include <memory>
+#include "Configuration.hpp"
+#include <NvsStore.hpp>
 
 #include <ArduinoJson.h>
 
-#include <NvsStore.hpp>
-
-#include "Configuration.hpp"
+#include <functional>
+#include <memory>
 
 namespace cornucopia::ugly_duckling::kernel::config {
 

--- a/components/kernel/src/config/NvsConfiguration.hpp
+++ b/components/kernel/src/config/NvsConfiguration.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "Configuration.hpp"
 #include <NvsStore.hpp>
 
@@ -7,6 +6,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 
 namespace cornucopia::ugly_duckling::kernel::config {
 

--- a/components/kernel/src/config/StoredConfig.hpp
+++ b/components/kernel/src/config/StoredConfig.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
-#include <memory>
-#include <string>
-#include <utility>
+#include "ConfigEnvelope.hpp"
+#include <Log.hpp>
+#include <NvsStore.hpp>
 
 #include <ArduinoJson.h>
 
-#include <Log.hpp>
-
-#include "ConfigEnvelope.hpp"
-#include <NvsStore.hpp>
+#include <memory>
+#include <string>
+#include <utility>
 
 namespace cornucopia::ugly_duckling::kernel::config {
 

--- a/components/kernel/src/drivers/BatteryDriver.hpp
+++ b/components/kernel/src/drivers/BatteryDriver.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <chrono>
-#include <limits>
-
 #include <Pin.hpp>
 #include <Telemetry.hpp>
+
+#include <chrono>
+#include <limits>
 #include <utility>
 
 using cornucopia::ugly_duckling::kernel::PinPtr;
@@ -48,8 +48,7 @@ public:
         if (voltage < 0) {
             return -1.0;
         }
-        auto percentage = static_cast<double>(voltage - parameters.shutdownThreshold) /
-               (parameters.maximumVoltage - parameters.shutdownThreshold) * 100.0;
+        auto percentage = static_cast<double>(voltage - parameters.shutdownThreshold) / (parameters.maximumVoltage - parameters.shutdownThreshold) * 100.0;
         if (percentage < 0) {
             return 0.0;
         }

--- a/components/kernel/src/drivers/BleDriver.hpp
+++ b/components/kernel/src/drivers/BleDriver.hpp
@@ -1,22 +1,26 @@
 #pragma once
 
+#include "WifiApRecord.hpp"
+#include <Log.hpp>
+#include <NvsStore.hpp>
+
+#include <time.h>
+
 #include <array>
 #include <chrono>
 #include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <time.h>
-
-#include "WifiApRecord.hpp"
-#include <Log.hpp>
-#include <NvsStore.hpp>
 
 // NimBleDriver and everything it needs from the "bt" component are only available when
 // CONFIG_BT_NIMBLE_ENABLED is set. Spinach (pre-MK10 devices) disables CONFIG_BT_ENABLED
 // entirely — see docs/specs/Bluetooth.md ("Platform support decision") — which drops the
 // bt component's nimble/host include paths, so these headers wouldn't even resolve there.
 #ifdef CONFIG_BT_NIMBLE_ENABLED
+#include <EspException.hpp>
+
+#include <ArduinoJson.h>
 #include <esp_random.h>
 #include <host/ble_gatt.h>
 #include <host/ble_hs.h>    // NOLINT(misc-header-include-cycle) -- ble_hs.h and ble_gap.h include each other; cycle is in ESP-IDF, not our code
@@ -29,9 +33,6 @@
 #include <services/dis/ble_svc_dis.h>
 #include <services/gap/ble_svc_gap.h>
 #include <services/gatt/ble_svc_gatt.h>
-
-#include <ArduinoJson.h>
-#include <EspException.hpp>
 #endif
 
 using namespace std::chrono;
@@ -54,14 +55,23 @@ enum class BleStatus : std::uint8_t {
 class BleDriver {
 public:
     virtual ~BleDriver() = default;
-    virtual BleStatus getStatus() { return BleStatus::Disabled; }
-    virtual void setBatteryLevel(uint8_t /*unused*/) {}
-    virtual void setOnTimeReceived(const std::function<void(time_t)>& /*unused*/) {}
-    virtual void setOnWifiScanRequested(const std::function<void()>& /*unused*/) {}
-    virtual void setOnWifiCredentialsReceived(const std::function<void(std::string, std::string)>& /*unused*/) {}
-    virtual void setOnWifiControlReceived(const std::function<void(std::string)>& /*unused*/) {}
-    virtual void setWifiStatus(const std::string& /*unused*/) {}
-    virtual void setScanResults(const std::vector<WifiApRecord>& /*unused*/) {}
+    virtual BleStatus getStatus() {
+        return BleStatus::Disabled;
+    }
+    virtual void setBatteryLevel(uint8_t /*unused*/) {
+    }
+    virtual void setOnTimeReceived(const std::function<void(time_t)>& /*unused*/) {
+    }
+    virtual void setOnWifiScanRequested(const std::function<void()>& /*unused*/) {
+    }
+    virtual void setOnWifiCredentialsReceived(const std::function<void(std::string, std::string)>& /*unused*/) {
+    }
+    virtual void setOnWifiControlReceived(const std::function<void(std::string)>& /*unused*/) {
+    }
+    virtual void setWifiStatus(const std::string& /*unused*/) {
+    }
+    virtual void setScanResults(const std::vector<WifiApRecord>& /*unused*/) {
+    }
 };
 
 #ifdef CONFIG_BT_NIMBLE_ENABLED
@@ -261,7 +271,7 @@ private:
     }
 
     static std::array<uint8_t, 6> loadOrGenerateAddress(NvsStore& nvs) {
-        std::array<uint8_t, 6> addr { };
+        std::array<uint8_t, 6> addr {};
         JsonDocument doc;
         if (nvs.getJson("addr", doc) && doc.is<JsonArray>() && doc.as<JsonArray>().size() == 6) {
             auto arr = doc.as<JsonArray>();
@@ -399,7 +409,7 @@ private:
 
     static int ctsGetRefTimeInfo(struct ble_svc_cts_reference_time_info* rti) {
         rti->time_source = TIME_SOURCE_UNKNOWN;
-        rti->time_accuracy = 254;           // unknown
+        rti->time_accuracy = 254;    // unknown
         rti->days_since_update = 0;
         rti->hours_since_update = 0;
         return 0;
@@ -519,7 +529,7 @@ private:
     // old legacy-advertising implementation there's no need to split fields between a primary ad
     // and a separate scan response). Returns false (and sets status = Error) on failure.
     bool configureAndSetData(uint8_t instance) {
-        struct ble_gap_ext_adv_params params = { };
+        struct ble_gap_ext_adv_params params = {};
         params.connectable = 1;    // must accept CONNECT_IND for phone-based WiFi provisioning
         params.own_addr_type = BLE_OWN_ADDR_RANDOM;
         params.primary_phy = BLE_HCI_LE_PHY_1M;
@@ -546,7 +556,7 @@ private:
         } };
 
         const char* name = ble_svc_gap_device_name();
-        struct ble_hs_adv_fields adFields = { };
+        struct ble_hs_adv_fields adFields = {};
         adFields.flags = BLE_HS_ADV_F_DISC_GEN | BLE_HS_ADV_F_BREDR_UNSUP;
         adFields.name = reinterpret_cast<const uint8_t*>(name);
         adFields.name_len = static_cast<uint8_t>(strlen(name));
@@ -601,7 +611,7 @@ private:
     int connHandle { -1 };
     bool scanInProgress { false };
     std::string wifiStatus;
-    struct ble_npl_callout advRestartCallout { };
+    struct ble_npl_callout advRestartCallout {};
     bool advConfigured { false };    // see startAdvertising(): configure/set-data only needed once
 
     // Ugly Duckling Service — UUID: 100D32C7-A4E6-4F72-8D7A-A61871CE4FD6
@@ -655,22 +665,22 @@ private:
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     inline static ble_gatt_dsc_def scanResultsDscs[] = {
         { .uuid = &userDescUuid.u, .att_flags = BLE_ATT_F_READ, .min_key_size = 0, .access_cb = userDescAccessCallback, .arg = scanResultsLabel },
-        { },
+        {},
     };
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     inline static ble_gatt_dsc_def wifiStatusDscs[] = {
         { .uuid = &userDescUuid.u, .att_flags = BLE_ATT_F_READ, .min_key_size = 0, .access_cb = userDescAccessCallback, .arg = wifiStatusLabel },
-        { },
+        {},
     };
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     inline static ble_gatt_dsc_def wifiCredentialsDscs[] = {
         { .uuid = &userDescUuid.u, .att_flags = BLE_ATT_F_READ, .min_key_size = 0, .access_cb = userDescAccessCallback, .arg = wifiCredentialsLabel },
-        { },
+        {},
     };
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     inline static ble_gatt_dsc_def wifiControlDscs[] = {
         { .uuid = &userDescUuid.u, .att_flags = BLE_ATT_F_READ, .min_key_size = 0, .access_cb = userDescAccessCallback, .arg = wifiControlLabel },
-        { },
+        {},
     };
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -715,7 +725,7 @@ private:
             .val_handle = nullptr,
             .cpfd = nullptr,
         },
-        { },    // terminator
+        {},    // terminator
     };
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -726,7 +736,7 @@ private:
             .includes = nullptr,
             .characteristics = uglyDucklingChrs,
         },
-        { },    // terminator
+        {},    // terminator
     };
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/components/kernel/src/drivers/Bq27220Driver.hpp
+++ b/components/kernel/src/drivers/Bq27220Driver.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
+#include <I2CManager.hpp>
+#include <drivers/BatteryDriver.hpp>
+
+#include <bq27220.h>
+
 #include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
-
-#include <bq27220.h>
-
-#include <I2CManager.hpp>
-#include <drivers/BatteryDriver.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/kernel/src/drivers/BuzzerDriver.hpp
+++ b/components/kernel/src/drivers/BuzzerDriver.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-#include <mutex>
-
-#include <esp_timer.h>
-
 #include <Log.hpp>
 #include <Pin.hpp>
 #include <PowerManager.hpp>
 #include <PwmManager.hpp>
 #include <drivers/SharedEnable.hpp>
+
+#include <esp_timer.h>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
 
 using namespace std::chrono;
 

--- a/components/kernel/src/drivers/Drv8801Driver.hpp
+++ b/components/kernel/src/drivers/Drv8801Driver.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <memory>
-
 #include <Log.hpp>
 #include <Pin.hpp>
 #include <PwmManager.hpp>
 #include <drivers/MotorDriver.hpp>
 #include <drivers/SharedEnable.hpp>
+
+#include <memory>
 
 namespace cornucopia::ugly_duckling::kernel::drivers {
 

--- a/components/kernel/src/drivers/Drv8833Driver.hpp
+++ b/components/kernel/src/drivers/Drv8833Driver.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <memory>
-
 #include <Log.hpp>
 #include <Pin.hpp>
 #include <PwmManager.hpp>
 #include <drivers/MotorDriver.hpp>
 #include <drivers/SharedEnable.hpp>
+
+#include <memory>
 
 namespace cornucopia::ugly_duckling::kernel::drivers {
 

--- a/components/kernel/src/drivers/Drv8848Driver.hpp
+++ b/components/kernel/src/drivers/Drv8848Driver.hpp
@@ -13,4 +13,4 @@ namespace cornucopia::ugly_duckling::kernel::drivers {
  */
 using Drv8848Driver = Drv8833Driver;
 
-} // namespace cornucopia::ugly_duckling::kernel::drivers
+}    // namespace cornucopia::ugly_duckling::kernel::drivers

--- a/components/kernel/src/drivers/Drv8874Driver.hpp
+++ b/components/kernel/src/drivers/Drv8874Driver.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <memory>
-
 #include <Log.hpp>
 #include <Pin.hpp>
 #include <PwmManager.hpp>
 #include <drivers/MotorDriver.hpp>
 #include <drivers/SharedEnable.hpp>
+
+#include <memory>
 
 namespace cornucopia::ugly_duckling::kernel::drivers {
 

--- a/components/kernel/src/drivers/Ina219Driver.hpp
+++ b/components/kernel/src/drivers/Ina219Driver.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <ina219.h>
-
 #include <I2CManager.hpp>
+
+#include <ina219.h>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/kernel/src/drivers/Ina219Driver.hpp
+++ b/components/kernel/src/drivers/Ina219Driver.hpp
@@ -1,8 +1,9 @@
 #pragma once
-
 #include <I2CManager.hpp>
 
 #include <ina219.h>
+
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/kernel/src/drivers/LedDriver.hpp
+++ b/components/kernel/src/drivers/LedDriver.hpp
@@ -1,11 +1,11 @@
 #pragma once
-
 #include <Pin.hpp>
 #include <Queue.hpp>
 #include <Task.hpp>
 
 #include <atomic>
 #include <chrono>
+#include <string>
 #include <vector>
 
 using namespace std::chrono;

--- a/components/kernel/src/drivers/LedDriver.hpp
+++ b/components/kernel/src/drivers/LedDriver.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <atomic>
-#include <chrono>
-#include <vector>
-
 #include <Pin.hpp>
 #include <Queue.hpp>
 #include <Task.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <vector>
 
 using namespace std::chrono;
 

--- a/components/kernel/src/drivers/RtcDriver.hpp
+++ b/components/kernel/src/drivers/RtcDriver.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <chrono>
-#include <optional>
-#include <sys/time.h>
-#include <time.h>
-
-#include "esp_netif_sntp.h"
-#include "esp_sntp.h"
-
 #include <State.hpp>
 #include <Task.hpp>
 #include <config/Configuration.hpp>
+
+#include "esp_netif_sntp.h"
+#include "esp_sntp.h"
+#include <sys/time.h>
+#include <time.h>
+
+#include <chrono>
+#include <optional>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/kernel/src/drivers/RtcDriver.hpp
+++ b/components/kernel/src/drivers/RtcDriver.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <State.hpp>
 #include <Task.hpp>
 #include <config/Configuration.hpp>
@@ -10,7 +9,9 @@
 #include <time.h>
 
 #include <chrono>
+#include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/kernel/src/drivers/SharedEnable.hpp
+++ b/components/kernel/src/drivers/SharedEnable.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <Log.hpp>
+#include <Pin.hpp>
+
 #include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
-
-#include <Log.hpp>
-#include <Pin.hpp>
 
 namespace cornucopia::ugly_duckling::kernel::drivers {
 
@@ -86,7 +86,7 @@ public:
      * @brief Create a SharedEnable that does nothing on state changes.
      */
     static std::shared_ptr<SharedEnable> noOp() {
-        return std::make_shared<SharedEnable>([](bool) {});
+        return std::make_shared<SharedEnable>([](bool) { });
     }
 
     /**

--- a/components/kernel/src/drivers/SwitchManager.hpp
+++ b/components/kernel/src/drivers/SwitchManager.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Pin.hpp>
 #include <Queue.hpp>
 #include <Task.hpp>
@@ -9,7 +8,9 @@
 
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <mutex>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/kernel/src/drivers/SwitchManager.hpp
+++ b/components/kernel/src/drivers/SwitchManager.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <chrono>
-#include <functional>
-#include <mutex>
-#include <utility>
+#include <Pin.hpp>
+#include <Queue.hpp>
+#include <Task.hpp>
 
 #include <driver/gpio.h>
 #include <hal/gpio_types.h>
 
-#include <Pin.hpp>
-#include <Queue.hpp>
-#include <Task.hpp>
+#include <chrono>
+#include <functional>
+#include <mutex>
+#include <utility>
 
 using namespace std::chrono;
 

--- a/components/kernel/src/drivers/WiFiDriver.hpp
+++ b/components/kernel/src/drivers/WiFiDriver.hpp
@@ -10,6 +10,7 @@
 
 #include <ArduinoJson.h>
 #include <esp_event.h>
+#include <esp_sleep.h>
 #include <esp_wifi.h>
 #include <network_provisioning/manager.h>
 #include <network_provisioning/scheme_softap.h>

--- a/components/kernel/src/drivers/WiFiDriver.hpp
+++ b/components/kernel/src/drivers/WiFiDriver.hpp
@@ -1,5 +1,19 @@
 #pragma once
 
+#include "WifiApRecord.hpp"
+#include <Overloaded.hpp>
+#include <Queue.hpp>
+#include <State.hpp>
+#include <StateManager.hpp>
+#include <Task.hpp>
+#include <Telemetry.hpp>
+
+#include <ArduinoJson.h>
+#include <esp_event.h>
+#include <esp_wifi.h>
+#include <network_provisioning/manager.h>
+#include <network_provisioning/scheme_softap.h>
+
 #include <atomic>
 #include <chrono>
 #include <functional>
@@ -7,20 +21,6 @@
 #include <string>
 #include <variant>
 #include <vector>
-
-#include <esp_event.h>
-#include <esp_wifi.h>
-#include <network_provisioning/manager.h>
-#include <network_provisioning/scheme_softap.h>
-
-#include "WifiApRecord.hpp"
-#include <ArduinoJson.h>
-#include <Overloaded.hpp>
-#include <Queue.hpp>
-#include <State.hpp>
-#include <StateManager.hpp>
-#include <Task.hpp>
-#include <Telemetry.hpp>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
@@ -97,12 +97,12 @@ public:
 
     // Drops the current connection; the driver will reconnect immediately.
     void disconnect() {
-        eventQueue.offer(EvDisconnectCmd { });
+        eventQueue.offer(EvDisconnectCmd {});
     }
 
     // Turns off WiFi; the driver will not reconnect until new credentials are set.
     void disable() {
-        eventQueue.offer(EvDisableCmd { });
+        eventQueue.offer(EvDisableCmd {});
     }
 
     // Starts a WiFi scan and calls onComplete with the discovered APs when done.
@@ -113,7 +113,7 @@ public:
 
     void populateTelemetry(JsonObject& json) {
         if (networkReady.isSet()) {
-            wifi_ap_record_t apInfo = { };
+            wifi_ap_record_t apInfo = {};
             esp_err_t err = esp_wifi_sta_get_ap_info(&apInfo);
             if (err == ESP_OK) {
                 json["rssi"] = apInfo.rssi;
@@ -148,12 +148,15 @@ private:
     }
 
     static uint8_t wifiGenFromRecord(const wifi_ap_record_t& r) {
-        if (r.phy_11ax) { return 6;
-}
-        if (r.phy_11n) { return 4;
-}
-        if (r.phy_11g) { return 3;
-}
+        if (r.phy_11ax) {
+            return 6;
+        }
+        if (r.phy_11n) {
+            return 4;
+        }
+        if (r.phy_11g) {
+            return 3;
+        }
         return 1;
     }
 
@@ -220,7 +223,7 @@ private:
             case WIFI_EVENT_STA_START: {
                 LOGTD(WIFI, "Started");
                 stationStarted.set();
-                eventQueue.offer(EvStarted { });
+                eventQueue.offer(EvStarted {});
                 break;
             }
             case WIFI_EVENT_STA_STOP: {
@@ -273,7 +276,7 @@ private:
                     std::lock_guard<std::mutex> lock(metadataMutex);
                     ip = event->ip_info.ip;
                 }
-                eventQueue.offer(EvGotIp { });
+                eventQueue.offer(EvGotIp {});
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 LOGTD(WIFI, "Got IP - " IPSTR, IP2STR(&event->ip_info.ip));
                 break;
@@ -284,7 +287,7 @@ private:
                     std::lock_guard<std::mutex> lock(metadataMutex);
                     ip.reset();
                 }
-                eventQueue.offer(EvLostIp { });
+                eventQueue.offer(EvLostIp {});
                 LOGTD(WIFI, "Lost IP");
                 break;
             }
@@ -320,7 +323,7 @@ private:
             }
             case NETWORK_PROV_END: {
                 LOGTD(WIFI, "provisioning finished");
-                eventQueue.offer(EvProvisioningDone { });
+                eventQueue.offer(EvProvisioningDone {});
                 network_prov_mgr_deinit();
                 break;
             }
@@ -421,7 +424,7 @@ private:
                                 cb({});
                                 return;
                             }
-                            wifi_scan_config_t scanConfig = { };
+                            wifi_scan_config_t scanConfig = {};
                             scanTriggeredByProvisioning = false;
                             esp_err_t err = esp_wifi_scan_start(&scanConfig, false);
                             if (err != ESP_OK) {
@@ -441,7 +444,7 @@ private:
                                 setWifiStatusInternal("failed:password_too_long");
                                 return;
                             }
-                            wifi_config_t config = { };
+                            wifi_config_t config = {};
                             strncpy(reinterpret_cast<char*>(config.sta.ssid), ev.ssid.c_str(), sizeof(config.sta.ssid) - 1);
                             strncpy(reinterpret_cast<char*>(config.sta.password), ev.password.c_str(), sizeof(config.sta.password) - 1);
                             ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &config));
@@ -473,7 +476,7 @@ private:
 
 #ifdef WOKWI
         LOGTD(WIFI, "Skipping provisioning on Wokwi");
-        wifi_config_t wifiConfig = { };
+        wifi_config_t wifiConfig = {};
         strncpy(reinterpret_cast<char*>(wifiConfig.sta.ssid), "Wokwi-GUEST", sizeof(wifiConfig.sta.ssid) - 1);
         wifiConfig.sta.ssid[sizeof(wifiConfig.sta.ssid) - 1] = '\0';
         wifiConfig.sta.password[0] = '\0';

--- a/components/kernel/src/mqtt/MqttDriver.hpp
+++ b/components/kernel/src/mqtt/MqttDriver.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Log.hpp>
 #include <Overloaded.hpp>
 #include <Queue.hpp>
@@ -13,8 +12,11 @@
 
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <optional>
+#include <stdexcept>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>

--- a/components/kernel/src/mqtt/MqttDriver.hpp
+++ b/components/kernel/src/mqtt/MqttDriver.hpp
@@ -1,16 +1,5 @@
 #pragma once
 
-#include <atomic>
-#include <chrono>
-#include <memory>
-#include <optional>
-#include <utility>
-#include <variant>
-#include <vector>
-
-#include <esp_event.h>
-#include <mqtt_client.h>
-
 #include <Log.hpp>
 #include <Overloaded.hpp>
 #include <Queue.hpp>
@@ -19,12 +8,24 @@
 #include <config/Configuration.hpp>
 #include <mqtt/PendingMessages.hpp>
 
+#include <esp_event.h>
+#include <mqtt_client.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <variant>
+#include <vector>
+
 using namespace std::chrono;
 using namespace std::chrono_literals;
 using namespace cornucopia::ugly_duckling::kernel;
 
 // Forward-declare the drivers namespace so the using directive works regardless of include order
-namespace cornucopia::ugly_duckling::kernel::drivers {}
+namespace cornucopia::ugly_duckling::kernel::drivers {
+}
 using namespace cornucopia::ugly_duckling::kernel::drivers;
 
 namespace cornucopia::ugly_duckling::kernel::mqtt {
@@ -82,7 +83,7 @@ public:
         , incomingQueue("mqtt-incoming", config->queueSize.get()) {
 
         Task::run("mqtt", 5120, [this](Task& task) {
-            esp_mqtt_client_config_t mqttConfig = { };
+            esp_mqtt_client_config_t mqttConfig = {};
             client = esp_mqtt_client_init(&mqttConfig);
 
             ESP_ERROR_CHECK(esp_mqtt_client_register_event(client, MQTT_EVENT_ANY, handleMqttEventCallback, this));
@@ -142,17 +143,17 @@ public:
                     .path = nullptr,
                     .port = port,
                 },
-                .verification { },
+                .verification {},
             },
             .credentials {
                 .username = nullptr,
                 .client_id = clientId.c_str(),
                 .set_null_client_id = false,
-                .authentication { },
+                .authentication {},
             },
             // TODO Configure last will
             .session {
-                .last_will { },
+                .last_will {},
                 .disable_clean_session = false,
                 .keepalive = duration_cast<seconds>(MQTT_SESSION_KEEP_ALIVE).count(),
                 .disable_keepalive = false,
@@ -164,16 +165,16 @@ public:
                 .timeout_ms = duration_cast<milliseconds>(MQTT_NETWORK_TIMEOUT).count(),
                 .refresh_connection_after_ms = 0,    // No need to refresh connection
                 .disable_auto_reconnect = false,
-                .tcp_keep_alive_cfg = { },
+                .tcp_keep_alive_cfg = {},
                 .transport = nullptr,    // Use default transport
                 .if_name = nullptr,      // Use default interface
             },
-            .task { },
+            .task {},
             .buffer {
                 .size = 8192,
                 .out_size = 4096,
             },
-            .outbox { },
+            .outbox {},
         };
 
         LOGTD(MQTT, "server: %s:%" PRIu32 ", client ID is '%s'",
@@ -456,7 +457,7 @@ private:
 
         stopClient();
 
-        esp_mqtt_client_config_t mqttConfig { };
+        esp_mqtt_client_config_t mqttConfig {};
         try {
             configMqttClient(mqttConfig);
         } catch (const std::exception& e) {
@@ -518,7 +519,7 @@ private:
             case MQTT_EVENT_DISCONNECTED: {
                 LOGTD(MQTT, "Disconnected from MQTT server");
                 ready.clear();
-                eventQueue.offerIn(MQTT_QUEUE_TIMEOUT, Disconnected { });
+                eventQueue.offerIn(MQTT_QUEUE_TIMEOUT, Disconnected {});
                 break;
             }
             case MQTT_EVENT_SUBSCRIBED: {
@@ -735,7 +736,7 @@ private:
     StateSource& ready;
 
     std::string hostname;
-    uint32_t port { };
+    uint32_t port {};
     esp_mqtt_client_handle_t client;
 
     using MqttEvent = std::variant<Connected, Disconnected, MessagePublished, Subscribed, OutgoingMessage, Subscription, ConnectedListenerRegistration>;

--- a/components/kernel/src/mqtt/MqttDriver.hpp
+++ b/components/kernel/src/mqtt/MqttDriver.hpp
@@ -27,7 +27,7 @@ using namespace cornucopia::ugly_duckling::kernel;
 
 // Forward-declare the drivers namespace so the using directive works regardless of include order
 namespace cornucopia::ugly_duckling::kernel::drivers {
-}
+}    // namespace cornucopia::ugly_duckling::kernel::drivers
 using namespace cornucopia::ugly_duckling::kernel::drivers;
 
 namespace cornucopia::ugly_duckling::kernel::mqtt {

--- a/components/kernel/src/mqtt/MqttLog.hpp
+++ b/components/kernel/src/mqtt/MqttLog.hpp
@@ -1,8 +1,10 @@
 #pragma once
-
 #include <LogJson.hpp>
 #include <Task.hpp>
 #include <mqtt/MqttRoot.hpp>
+
+#include <memory>
+#include <string>
 
 namespace cornucopia::ugly_duckling::kernel::mqtt {
 

--- a/components/kernel/src/mqtt/MqttRoot.hpp
+++ b/components/kernel/src/mqtt/MqttRoot.hpp
@@ -1,9 +1,10 @@
 #pragma once
-
 #include <mqtt/MqttDriver.hpp>
 
 #include <chrono>
+#include <functional>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/components/kernel/src/mqtt/MqttRoot.hpp
+++ b/components/kernel/src/mqtt/MqttRoot.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <mqtt/MqttDriver.hpp>
+
 #include <chrono>
 #include <memory>
 #include <unordered_map>
-#include <vector>
-
-#include <mqtt/MqttDriver.hpp>
 #include <utility>
+#include <vector>
 
 namespace cornucopia::ugly_duckling::kernel::mqtt {
 

--- a/components/kernel/src/mqtt/PendingMessages.hpp
+++ b/components/kernel/src/mqtt/PendingMessages.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <Queue.hpp>
+
 #include <memory>
 #include <mutex>
 #include <unordered_map>
-
-#include <Queue.hpp>
 
 namespace cornucopia::ugly_duckling::kernel::mqtt {
 

--- a/components/kernel/test/ConfigBootPlanTest.cpp
+++ b/components/kernel/test/ConfigBootPlanTest.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-
 #include <config/ConfigBootPlan.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/kernel/test/ConfigEnvelopeTest.cpp
+++ b/components/kernel/test/ConfigEnvelopeTest.cpp
@@ -1,8 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
+#include <config/ConfigEnvelope.hpp>
 
 #include <string>
-
-#include <config/ConfigEnvelope.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::config;

--- a/components/kernel/test/ConfigStagingTest.cpp
+++ b/components/kernel/test/ConfigStagingTest.cpp
@@ -1,9 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
+#include <config/ConfigStaging.hpp>
 
 #include <string>
 #include <unordered_map>
-
-#include <config/ConfigStaging.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::config;

--- a/components/kernel/test/ConfigStateTest.cpp
+++ b/components/kernel/test/ConfigStateTest.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-
 #include <config/ConfigState.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/kernel/test/ConfigurationTest.cpp
+++ b/components/kernel/test/ConfigurationTest.cpp
@@ -1,11 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_exception.hpp>
+#include <config/Configuration.hpp>
 
 #include <chrono>
 #include <string>
-
-#include <config/Configuration.hpp>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/kernel/test/FirmwareUpdateDecisionTest.cpp
+++ b/components/kernel/test/FirmwareUpdateDecisionTest.cpp
@@ -1,6 +1,5 @@
-#include <catch2/catch_test_macros.hpp>
-
 #include <FirmwareUpdateDecision.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/kernel/test/MovingAverageTest.cpp
+++ b/components/kernel/test/MovingAverageTest.cpp
@@ -1,6 +1,5 @@
-#include <catch2/catch_test_macros.hpp>
-
 #include <MovingAverage.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/kernel/test/Strings.test.cpp
+++ b/components/kernel/test/Strings.test.cpp
@@ -1,6 +1,5 @@
-#include <catch2/catch_test_macros.hpp>
-
 #include <Strings.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/kernel/test/UpdateFilterTest.cpp
+++ b/components/kernel/test/UpdateFilterTest.cpp
@@ -1,9 +1,8 @@
+#include <UpdateFilter.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <string>
 #include <unordered_map>
-
-#include <UpdateFilter.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/components/peripherals-api/src/peripherals/api/IDoor.hpp
+++ b/components/peripherals-api/src/peripherals/api/IDoor.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <optional>
-#include <utility>
+#include "IPeripheral.hpp"
+#include "TargetState.hpp"
 
 #include <ArduinoJson.h>
 
-#include "IPeripheral.hpp"
-#include "TargetState.hpp"
+#include <optional>
+#include <utility>
 
 namespace cornucopia::ugly_duckling::peripherals::api {
 

--- a/components/peripherals-api/src/peripherals/api/IPeripheral.hpp
+++ b/components/peripherals-api/src/peripherals/api/IPeripheral.hpp
@@ -10,4 +10,4 @@ struct IPeripheral {
     virtual const std::string& getName() const = 0;
 };
 
-} // namespace cornucopia::ugly_duckling::peripherals::api
+}    // namespace cornucopia::ugly_duckling::peripherals::api

--- a/components/peripherals-api/src/peripherals/api/ITemperatureSensor.hpp
+++ b/components/peripherals-api/src/peripherals/api/ITemperatureSensor.hpp
@@ -6,7 +6,7 @@
 namespace cornucopia::ugly_duckling::peripherals::api {
 
 struct ITemperatureSensor : virtual IPeripheral {
-    virtual Celsius getTemperature() = 0;  // Returns a raw temperature reading
+    virtual Celsius getTemperature() = 0;    // Returns a raw temperature reading
 };
 
 }    // namespace cornucopia::ugly_duckling::peripherals::api

--- a/components/peripherals-api/src/peripherals/api/IValve.hpp
+++ b/components/peripherals-api/src/peripherals/api/IValve.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <ArduinoJson.h>
-
 #include "IPeripheral.hpp"
 #include "TargetState.hpp"
+
+#include <ArduinoJson.h>
 
 namespace cornucopia::ugly_duckling::peripherals::api {
 

--- a/components/peripherals-api/src/peripherals/api/TargetState.hpp
+++ b/components/peripherals-api/src/peripherals/api/TargetState.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <optional>
-
 #include <ArduinoJson.h>
+
+#include <optional>
 
 namespace cornucopia::ugly_duckling::peripherals::api {
 

--- a/components/peripherals/src/peripherals/I2CSettings.hpp
+++ b/components/peripherals/src/peripherals/I2CSettings.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <chrono>
-
 #include <I2CManager.hpp>
 #include <config/Configuration.hpp>
+
+#include <chrono>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/peripherals/src/peripherals/I2CSettings.hpp
+++ b/components/peripherals/src/peripherals/I2CSettings.hpp
@@ -1,9 +1,9 @@
 #pragma once
-
 #include <I2CManager.hpp>
 #include <config/Configuration.hpp>
 
 #include <chrono>
+#include <string>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/peripherals/src/peripherals/Motors.cpp
+++ b/components/peripherals/src/peripherals/Motors.cpp
@@ -1,6 +1,8 @@
 #include "Motors.hpp"
+
 #include "PeripheralException.hpp"
 #include "drivers/MotorDriver.hpp"
+
 #include <map>
 #include <memory>
 #include <string>

--- a/components/peripherals/src/peripherals/Motors.hpp
+++ b/components/peripherals/src/peripherals/Motors.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <drivers/MotorDriver.hpp>
+
 #include <map>
 #include <memory>
 #include <string>
-
-#include <drivers/MotorDriver.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel::drivers;
 

--- a/components/peripherals/src/peripherals/Peripheral.hpp
+++ b/components/peripherals/src/peripherals/Peripheral.hpp
@@ -1,12 +1,6 @@
 #pragma once
 
-#include <concepts>
-#include <functional>
-#include <map>
-#include <memory>
-#include <type_traits>
-#include <vector>
-
+#include "PeripheralException.hpp"
 #include <EspException.hpp>
 #include <I2CManager.hpp>
 #include <Manager.hpp>
@@ -17,10 +11,14 @@
 #include <config/Configuration.hpp>
 #include <drivers/SwitchManager.hpp>
 #include <mqtt/MqttRoot.hpp>
-
 #include <peripherals/api/IPeripheral.hpp>
 
-#include "PeripheralException.hpp"
+#include <concepts>
+#include <functional>
+#include <map>
+#include <memory>
+#include <type_traits>
+#include <vector>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;
@@ -95,11 +93,8 @@ template <
     typename Impl,
     std::derived_from<ConfigurationSection> TSettings,
     typename... RegisterAs>
-    requires (sizeof...(RegisterAs) == 0 || (std::derived_from<Impl, RegisterAs> && ...))
-PeripheralFactory makePeripheralFactory(const std::string& factoryType,
-    const std::string& peripheralType,
-    std::function<std::shared_ptr<Impl>(PeripheralInitParameters&, const std::shared_ptr<TSettings>&)> makeImpl,
-    std::function<std::shared_ptr<TSettings>()> makeSettings = [] { return std::make_shared<TSettings>(); }) {
+    requires(sizeof...(RegisterAs) == 0 || (std::derived_from<Impl, RegisterAs> && ...))
+PeripheralFactory makePeripheralFactory(const std::string& factoryType, const std::string& peripheralType, std::function<std::shared_ptr<Impl>(PeripheralInitParameters&, const std::shared_ptr<TSettings>&)> makeImpl, std::function<std::shared_ptr<TSettings>()> makeSettings = [] { return std::make_shared<TSettings>(); }) {
 
     // Build the factory using designated initializers (C++20+)
     auto effectiveType = peripheralType.empty() ? factoryType : peripheralType;

--- a/components/peripherals/src/peripherals/Peripheral.hpp
+++ b/components/peripherals/src/peripherals/Peripheral.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "PeripheralException.hpp"
 #include <EspException.hpp>
 #include <I2CManager.hpp>
@@ -17,6 +16,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/components/peripherals/src/peripherals/PeripheralException.hpp
+++ b/components/peripherals/src/peripherals/PeripheralException.hpp
@@ -1,6 +1,6 @@
 #pragma once
-
 #include <stdexcept>
+#include <string>
 
 namespace cornucopia::ugly_duckling::peripherals {
 

--- a/components/peripherals/src/peripherals/analog_meter/AnalogMeter.hpp
+++ b/components/peripherals/src/peripherals/analog_meter/AnalogMeter.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Log.hpp>
 #include <MovingAverage.hpp>
 #include <Named.hpp>
@@ -11,6 +10,8 @@
 #include <peripherals/Peripheral.hpp>
 
 #include <chrono>
+#include <memory>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/peripherals/src/peripherals/analog_meter/AnalogMeter.hpp
+++ b/components/peripherals/src/peripherals/analog_meter/AnalogMeter.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <chrono>
-#include <utility>
-
 #include <Log.hpp>
 #include <MovingAverage.hpp>
 #include <Named.hpp>
@@ -12,6 +9,9 @@
 #include <config/Configuration.hpp>
 #include <mqtt/MqttDriver.hpp>
 #include <peripherals/Peripheral.hpp>
+
+#include <chrono>
+#include <utility>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/peripherals/src/peripherals/door/Door.hpp
+++ b/components/peripherals/src/peripherals/door/Door.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Named.hpp>
 #include <Overloaded.hpp>
 #include <Queue.hpp>
@@ -16,7 +15,9 @@
 #include <concepts>
 #include <limits>
 #include <map>
+#include <memory>
 #include <mutex>
+#include <string>
 #include <utility>
 #include <variant>
 

--- a/components/peripherals/src/peripherals/door/Door.hpp
+++ b/components/peripherals/src/peripherals/door/Door.hpp
@@ -1,5 +1,17 @@
 #pragma once
 
+#include <Named.hpp>
+#include <Overloaded.hpp>
+#include <Queue.hpp>
+#include <Task.hpp>
+#include <Telemetry.hpp>
+#include <Watchdog.hpp>
+#include <drivers/MotorDriver.hpp>
+#include <drivers/SwitchManager.hpp>
+#include <peripherals/Motors.hpp>
+#include <peripherals/Peripheral.hpp>
+#include <peripherals/api/IDoor.hpp>
+
 #include <chrono>
 #include <concepts>
 #include <limits>
@@ -7,20 +19,6 @@
 #include <mutex>
 #include <utility>
 #include <variant>
-
-#include <Named.hpp>
-#include <Overloaded.hpp>
-#include <Queue.hpp>
-#include <Task.hpp>
-#include <Telemetry.hpp>
-#include <Watchdog.hpp>
-
-#include <drivers/MotorDriver.hpp>
-#include <drivers/SwitchManager.hpp>
-
-#include <peripherals/Motors.hpp>
-#include <peripherals/Peripheral.hpp>
-#include <peripherals/api/IDoor.hpp>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::drivers;
@@ -177,7 +175,7 @@ public:
 
     void shutdown(const ShutdownParameters& _params) override {
         if (operationState == OperationState::Running) {
-            updateQueue.put(ShutdownSpec { });
+            updateQueue.put(ShutdownSpec {});
         }
     }
 
@@ -315,7 +313,7 @@ private:
             case WatchdogState::TimedOut:
                 LOGTV(DOOR, "Watchdog timed out");
                 sleepLock.reset();
-                updateQueue.put(WatchdogTimeout { });
+                updateQueue.put(WatchdogTimeout {});
                 break;
         }
     }

--- a/components/peripherals/src/peripherals/environment/BitbangI2C.hpp
+++ b/components/peripherals/src/peripherals/environment/BitbangI2C.hpp
@@ -195,11 +195,11 @@ private:
 
 #ifdef ESP_PLATFORM
 
+#include <Pin.hpp>
+
 #include <esp_rom_sys.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/portmacro.h>
-
-#include <Pin.hpp>
 
 namespace cornucopia::ugly_duckling::peripherals::environment {
 

--- a/components/peripherals/src/peripherals/environment/ChirpSoilSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/ChirpSoilSensor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "Environment.hpp"
 #include <I2CManager.hpp>
 #include <peripherals/I2CSettings.hpp>
@@ -10,6 +9,7 @@
 
 #include <limits>
 #include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals;

--- a/components/peripherals/src/peripherals/environment/ChirpSoilSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/ChirpSoilSensor.hpp
@@ -1,18 +1,15 @@
 #pragma once
 
-#include <limits>
-#include <memory>
-
+#include "Environment.hpp"
 #include <I2CManager.hpp>
-
 #include <peripherals/I2CSettings.hpp>
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/ISoilMoistureSensor.hpp>
 #include <peripherals/api/ITemperatureSensor.hpp>
-
 #include <utils/DebouncedMeasurement.hpp>
 
-#include "Environment.hpp"
+#include <limits>
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals;

--- a/components/peripherals/src/peripherals/environment/Ds18B20SoilSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Ds18B20SoilSensor.hpp
@@ -1,18 +1,16 @@
 #pragma once
 
-#include <memory>
-#include <optional>
-#include <utility>
-
-#include <ds18x20.h>
-
+#include "Environment.hpp"
 #include <config/Configuration.hpp>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/ITemperatureSensor.hpp>
 #include <utils/DebouncedMeasurement.hpp>
 
-#include "Environment.hpp"
+#include <ds18x20.h>
+
+#include <memory>
+#include <optional>
+#include <utility>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::mqtt;

--- a/components/peripherals/src/peripherals/environment/Ds18B20SoilSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Ds18B20SoilSensor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "Environment.hpp"
 #include <config/Configuration.hpp>
 #include <peripherals/Peripheral.hpp>
@@ -10,6 +9,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/peripherals/src/peripherals/environment/Environment.hpp
+++ b/components/peripherals/src/peripherals/environment/Environment.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <concepts>
-#include <memory>
-
 #include <I2CManager.hpp>
 #include <config/Configuration.hpp>
-
 #include <peripherals/I2CSettings.hpp>
 #include <peripherals/Peripheral.hpp>
+
+#include <concepts>
+#include <memory>
 #include <utility>
 
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/peripherals/src/peripherals/environment/Hdc2010Sensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Hdc2010Sensor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "Environment.hpp"
 #include <I2CManager.hpp>
 #include <peripherals/I2CSettings.hpp>
@@ -10,6 +9,8 @@
 #include <freertos/task.h>
 
 #include <limits>
+#include <memory>
+#include <string>
 #include <utility>
 
 using namespace cornucopia::ugly_duckling::peripherals;

--- a/components/peripherals/src/peripherals/environment/Hdc2010Sensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Hdc2010Sensor.hpp
@@ -1,18 +1,16 @@
 #pragma once
 
-#include <limits>
-#include <utility>
+#include "Environment.hpp"
+#include <I2CManager.hpp>
+#include <peripherals/I2CSettings.hpp>
+#include <peripherals/Peripheral.hpp>
+#include <utils/DebouncedMeasurement.hpp>
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
-#include <I2CManager.hpp>
-#include <utils/DebouncedMeasurement.hpp>
-
-#include <peripherals/I2CSettings.hpp>
-#include <peripherals/Peripheral.hpp>
-
-#include "Environment.hpp"
+#include <limits>
+#include <utility>
 
 using namespace cornucopia::ugly_duckling::peripherals;
 
@@ -63,11 +61,11 @@ private:
                 uint8_t buf[4];
                 device->readReg(0x00, buf, 4);
                 uint16_t rawTemp = static_cast<uint16_t>(buf[0]) | (static_cast<uint16_t>(buf[1]) << 8);
-                uint16_t rawHum  = static_cast<uint16_t>(buf[2]) | (static_cast<uint16_t>(buf[3]) << 8);
+                uint16_t rawHum = static_cast<uint16_t>(buf[2]) | (static_cast<uint16_t>(buf[3]) << 8);
                 // Datasheet §8.3.4: maps 0–65535 to -40…+125 °C (range = 165 °C)
                 double temp = (static_cast<double>(rawTemp) / 65536.0 * 165.0) - 40.0;
                 // Datasheet §8.3.4: maps 0–65535 to 0…100 %RH
-                double hum  = static_cast<double>(rawHum)  / 65536.0 * 100.0;
+                double hum = static_cast<double>(rawHum) / 65536.0 * 100.0;
                 LOGTV(ENV, "Measured temperature: %.2f °C, humidity: %.2f %%", temp, hum);
                 return Reading { temp, hum };
             } catch (const std::exception& e) {

--- a/components/peripherals/src/peripherals/environment/Hw390SoilMoistureSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Hw390SoilMoistureSensor.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <memory>
-#include <utility>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/ISoilMoistureSensor.hpp>
-
 #include <utils/DebouncedMeasurement.hpp>
+
+#include <memory>
+#include <utility>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals;

--- a/components/peripherals/src/peripherals/environment/Hw390SoilMoistureSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Hw390SoilMoistureSensor.hpp
@@ -1,10 +1,10 @@
 #pragma once
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/ISoilMoistureSensor.hpp>
 #include <utils/DebouncedMeasurement.hpp>
 
 #include <memory>
+#include <string>
 #include <utility>
 
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/peripherals/src/peripherals/environment/KalmanFilterSoilSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/KalmanFilterSoilSensor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "Environment.hpp"
 #include <config/Configuration.hpp>
 #include <peripherals/Peripheral.hpp>
@@ -9,6 +8,7 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::utils::scheduling;

--- a/components/peripherals/src/peripherals/environment/KalmanFilterSoilSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/KalmanFilterSoilSensor.hpp
@@ -1,16 +1,14 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-
+#include "Environment.hpp"
 #include <config/Configuration.hpp>
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/ISoilMoistureSensor.hpp>
 #include <peripherals/api/ITemperatureSensor.hpp>
-
 #include <scheduling/MoistureKalmanFilter.hpp>
 
-#include "Environment.hpp"
+#include <chrono>
+#include <memory>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::utils::scheduling;
@@ -68,14 +66,14 @@ public:
         , rNormal(rNormal)
         , sensitivePeriodEnd(steady_clock::now() + sensitivePeriod) {
         LOGTI(ENV, "Initializing Kalman filter soil moisture sensor '%s' "
-             "wrapping moisture sensor '%s'"
-             " and temperature sensor '%s'"
-             "; initial moisture: %.1f%%"
-             ", initial beta: %.2f"
-             ", reference temp.: %.1f C"
-             ", process noise: %.2e (moisture) / %.2e (beta)"
-             ", measurement noise: %.2e (sensitive) / %.2e (normal)"
-             ", sensitive period: %lld s",
+                   "wrapping moisture sensor '%s'"
+                   " and temperature sensor '%s'"
+                   "; initial moisture: %.1f%%"
+                   ", initial beta: %.2f"
+                   ", reference temp.: %.1f C"
+                   ", process noise: %.2e (moisture) / %.2e (beta)"
+                   ", measurement noise: %.2e (sensitive) / %.2e (normal)"
+                   ", sensitive period: %lld s",
             name.c_str(),
             rawMoistureSensor->getName().c_str(),
             tempSensor->getName().c_str(),

--- a/components/peripherals/src/peripherals/environment/NtcTemperatureSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/NtcTemperatureSensor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Log.hpp>
 #include <Pin.hpp>
 #include <config/Configuration.hpp>
@@ -8,6 +7,8 @@
 #include <utils/DebouncedMeasurement.hpp>
 
 #include <cmath>
+#include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals::api;

--- a/components/peripherals/src/peripherals/environment/NtcTemperatureSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/NtcTemperatureSensor.hpp
@@ -1,15 +1,13 @@
 #pragma once
 
-#include <cmath>
-
 #include <Log.hpp>
 #include <Pin.hpp>
 #include <config/Configuration.hpp>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/ITemperatureSensor.hpp>
-
 #include <utils/DebouncedMeasurement.hpp>
+
+#include <cmath>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals::api;

--- a/components/peripherals/src/peripherals/environment/Sht2xSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Sht2xSensor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "Environment.hpp"
 #include <I2CManager.hpp>
 #include <peripherals/I2CSettings.hpp>
@@ -8,6 +7,8 @@
 #include <si7021.h>
 
 #include <limits>
+#include <memory>
+#include <string>
 #include <utility>
 
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/peripherals/src/peripherals/environment/Sht2xSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Sht2xSensor.hpp
@@ -1,16 +1,14 @@
 #pragma once
 
-#include <limits>
-#include <utility>
-
-#include <si7021.h>
-
+#include "Environment.hpp"
 #include <I2CManager.hpp>
-
 #include <peripherals/I2CSettings.hpp>
 #include <peripherals/Peripheral.hpp>
 
-#include "Environment.hpp"
+#include <si7021.h>
+
+#include <limits>
+#include <utility>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals;

--- a/components/peripherals/src/peripherals/environment/Sht3xSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Sht3xSensor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include "Environment.hpp"
 #include <I2CManager.hpp>
 #include <peripherals/I2CSettings.hpp>
@@ -9,6 +8,8 @@
 #include <sht3x.h>
 
 #include <limits>
+#include <memory>
+#include <string>
 #include <utility>
 
 using namespace cornucopia::ugly_duckling::peripherals;

--- a/components/peripherals/src/peripherals/environment/Sht3xSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/Sht3xSensor.hpp
@@ -1,17 +1,15 @@
 #pragma once
 
-#include <limits>
-#include <utility>
+#include "Environment.hpp"
+#include <I2CManager.hpp>
+#include <peripherals/I2CSettings.hpp>
+#include <peripherals/Peripheral.hpp>
+#include <utils/DebouncedMeasurement.hpp>
 
 #include <sht3x.h>
 
-#include <I2CManager.hpp>
-#include <utils/DebouncedMeasurement.hpp>
-
-#include <peripherals/I2CSettings.hpp>
-#include <peripherals/Peripheral.hpp>
-
-#include "Environment.hpp"
+#include <limits>
+#include <utility>
 
 using namespace cornucopia::ugly_duckling::peripherals;
 

--- a/components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 
 /*
  * Two flavors of Spadefoot Toad soil sensor live in this file:

--- a/components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp
+++ b/components/peripherals/src/peripherals/environment/SpadefootToadSensor.hpp
@@ -21,30 +21,26 @@
  *   whether a general bitbang transport is warranted — do not copy this class.
  */
 
-#include <limits>
-#include <memory>
-#include <mutex>
-#include <stdexcept>
-#include <vector>
+#include "BitbangI2C.hpp"
+#include "Environment.hpp"
+#include <I2CManager.hpp>
+#include <Task.hpp>
+#include <peripherals/I2CSettings.hpp>
+#include <peripherals/Peripheral.hpp>
+#include <peripherals/api/ISoilMoistureSensor.hpp>
+#include <peripherals/api/ITemperatureSensor.hpp>
+#include <utils/DebouncedMeasurement.hpp>
 
 #include <driver/gpio.h>
 #include <esp_rom_sys.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
-#include <I2CManager.hpp>
-#include <Task.hpp>
-
-#include "BitbangI2C.hpp"
-
-#include <peripherals/I2CSettings.hpp>
-#include <peripherals/Peripheral.hpp>
-#include <peripherals/api/ISoilMoistureSensor.hpp>
-#include <peripherals/api/ITemperatureSensor.hpp>
-
-#include <utils/DebouncedMeasurement.hpp>
-
-#include "Environment.hpp"
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <vector>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::peripherals;

--- a/components/peripherals/src/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/components/peripherals/src/peripherals/fence/ElectricFenceMonitor.hpp
@@ -1,11 +1,12 @@
 #pragma once
-
 #include <PulseCounter.hpp>
 #include <Queue.hpp>
 #include <Telemetry.hpp>
 #include <peripherals/Peripheral.hpp>
 
 #include <chrono>
+#include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/components/peripherals/src/peripherals/fence/ElectricFenceMonitor.hpp
+++ b/components/peripherals/src/peripherals/fence/ElectricFenceMonitor.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <chrono>
-#include <vector>
-
 #include <PulseCounter.hpp>
 #include <Queue.hpp>
 #include <Telemetry.hpp>
-
 #include <peripherals/Peripheral.hpp>
+
+#include <chrono>
 #include <utility>
+#include <vector>
 
 using namespace std::chrono_literals;
 using namespace cornucopia::ugly_duckling::kernel;

--- a/components/peripherals/src/peripherals/flow_meter/FlowMeter.hpp
+++ b/components/peripherals/src/peripherals/flow_meter/FlowMeter.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <PulseCounter.hpp>
 #include <Task.hpp>
 #include <Telemetry.hpp>
@@ -10,7 +9,9 @@
 #include <ArduinoJson.h>
 
 #include <chrono>
+#include <memory>
 #include <mutex>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/peripherals/src/peripherals/flow_meter/FlowMeter.hpp
+++ b/components/peripherals/src/peripherals/flow_meter/FlowMeter.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <chrono>
-#include <mutex>
-
-#include <ArduinoJson.h>
 #include <PulseCounter.hpp>
 #include <Task.hpp>
 #include <Telemetry.hpp>
 #include <mqtt/MqttDriver.hpp>
-#include <utility>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/IFlowMeter.hpp>
+
+#include <ArduinoJson.h>
+
+#include <chrono>
+#include <mutex>
+#include <utility>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::kernel::mqtt;

--- a/components/peripherals/src/peripherals/light_sensor/AnalogLightSensor.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/AnalogLightSensor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Pin.hpp>
 #include <Telemetry.hpp>
 #include <config/Configuration.hpp>
@@ -11,6 +10,7 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/peripherals/src/peripherals/light_sensor/AnalogLightSensor.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/AnalogLightSensor.hpp
@@ -1,17 +1,16 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-
-#include <esp_system.h>
-
 #include <Pin.hpp>
 #include <Telemetry.hpp>
 #include <config/Configuration.hpp>
-
 #include <peripherals/I2CSettings.hpp>
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/light_sensor/LightSensor.hpp>
+
+#include <esp_system.h>
+
+#include <chrono>
+#include <memory>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/peripherals/src/peripherals/light_sensor/Bh1750.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/Bh1750.hpp
@@ -1,19 +1,17 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-
-#include <esp_system.h>
-
-#include <bh1750.h>
-
 #include <I2CManager.hpp>
 #include <Telemetry.hpp>
 #include <config/Configuration.hpp>
-
 #include <peripherals/I2CSettings.hpp>
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/light_sensor/LightSensor.hpp>
+
+#include <bh1750.h>
+#include <esp_system.h>
+
+#include <chrono>
+#include <memory>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/peripherals/src/peripherals/light_sensor/Bh1750.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/Bh1750.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <I2CManager.hpp>
 #include <Telemetry.hpp>
 #include <config/Configuration.hpp>
@@ -12,6 +11,7 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/peripherals/src/peripherals/light_sensor/LightSensor.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/LightSensor.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <I2CManager.hpp>
 #include <MovingAverage.hpp>
 #include <Named.hpp>
@@ -11,6 +10,7 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/peripherals/src/peripherals/light_sensor/LightSensor.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/LightSensor.hpp
@@ -1,18 +1,17 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-#include <mutex>
-#include <utility>
-
 #include <I2CManager.hpp>
 #include <MovingAverage.hpp>
 #include <Named.hpp>
 #include <config/Configuration.hpp>
-
 #include <peripherals/I2CSettings.hpp>
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/ILightSensor.hpp>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <utility>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/peripherals/src/peripherals/light_sensor/Tsl2591.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/Tsl2591.hpp
@@ -1,17 +1,16 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-
-#include <tsl2591.h>
-
 #include <I2CManager.hpp>
 #include <Telemetry.hpp>
 #include <config/Configuration.hpp>
-
 #include <peripherals/I2CSettings.hpp>
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/light_sensor/LightSensor.hpp>
+
+#include <tsl2591.h>
+
+#include <chrono>
+#include <memory>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/peripherals/src/peripherals/light_sensor/Tsl2591.hpp
+++ b/components/peripherals/src/peripherals/light_sensor/Tsl2591.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <I2CManager.hpp>
 #include <Telemetry.hpp>
 #include <config/Configuration.hpp>
@@ -11,6 +10,7 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
 #include <utility>
 
 using namespace std::chrono;

--- a/components/peripherals/src/peripherals/multiplexer/Xl9535.hpp
+++ b/components/peripherals/src/peripherals/multiplexer/Xl9535.hpp
@@ -1,8 +1,9 @@
 #pragma once
-
 #include <Pin.hpp>
 #include <config/Configuration.hpp>
 
+#include <memory>
+#include <string>
 #include <utility>
 
 namespace cornucopia::ugly_duckling::peripherals::multiplexer {

--- a/components/peripherals/src/peripherals/multiplexer/Xl9535.hpp
+++ b/components/peripherals/src/peripherals/multiplexer/Xl9535.hpp
@@ -2,6 +2,7 @@
 
 #include <Pin.hpp>
 #include <config/Configuration.hpp>
+
 #include <utility>
 
 namespace cornucopia::ugly_duckling::peripherals::multiplexer {

--- a/components/peripherals/src/peripherals/valve/Valve.hpp
+++ b/components/peripherals/src/peripherals/valve/Valve.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Named.hpp>
 #include <NvsStore.hpp>
 #include <Task.hpp>
@@ -14,6 +13,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <string>
 #include <utility>
 #include <variant>
 

--- a/components/peripherals/src/peripherals/valve/Valve.hpp
+++ b/components/peripherals/src/peripherals/valve/Valve.hpp
@@ -1,22 +1,21 @@
 #pragma once
 
-#include <atomic>
-#include <chrono>
-#include <memory>
-#include <utility>
-#include <variant>
-
-#include <ArduinoJson.h>
-
 #include <Named.hpp>
 #include <NvsStore.hpp>
 #include <Task.hpp>
 #include <Time.hpp>
 #include <drivers/MotorDriver.hpp>
-
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/IValve.hpp>
 #include <peripherals/valve/ValveControlStrategy.hpp>
+
+#include <ArduinoJson.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <utility>
+#include <variant>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/peripherals/src/peripherals/valve/ValveControlStrategy.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveControlStrategy.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <chrono>
-#include <cstdint>
-
 #include <Task.hpp>
 #include <drivers/MotorDriver.hpp>
-
 #include <peripherals/api/IValve.hpp>
+
+#include <chrono>
+#include <cstdint>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/peripherals/src/peripherals/valve/ValveControlStrategy.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveControlStrategy.hpp
@@ -1,11 +1,12 @@
 #pragma once
-
 #include <Task.hpp>
 #include <drivers/MotorDriver.hpp>
 #include <peripherals/api/IValve.hpp>
 
 #include <chrono>
 #include <cstdint>
+#include <memory>
+#include <string>
 
 using namespace std::chrono;
 using namespace cornucopia::ugly_duckling::kernel::drivers;

--- a/components/peripherals/src/peripherals/valve/ValveFactory.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveFactory.hpp
@@ -1,20 +1,19 @@
 #pragma once
 
-#include <chrono>
-#include <memory>
-
-#include <ArduinoJson.h>
-
 #include <Task.hpp>
 #include <Telemetry.hpp>
 #include <config/Configuration.hpp>
 #include <drivers/MotorDriver.hpp>
-
 #include <peripherals/Motors.hpp>
 #include <peripherals/Peripheral.hpp>
 #include <peripherals/api/IValve.hpp>
 #include <peripherals/valve/Valve.hpp>
 #include <peripherals/valve/ValveSettings.hpp>
+
+#include <ArduinoJson.h>
+
+#include <chrono>
+#include <memory>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/peripherals/src/peripherals/valve/ValveFactory.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveFactory.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <Task.hpp>
 #include <Telemetry.hpp>
 #include <config/Configuration.hpp>
@@ -14,6 +13,7 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/peripherals/src/peripherals/valve/ValveSettings.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveSettings.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <config/Configuration.hpp>
 #include <peripherals/api/IValve.hpp>
 #include <peripherals/valve/ValveControlStrategy.hpp>
@@ -7,6 +6,8 @@
 #include <ArduinoJson.h>
 
 #include <chrono>
+#include <memory>
+#include <string>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/peripherals/src/peripherals/valve/ValveSettings.hpp
+++ b/components/peripherals/src/peripherals/valve/ValveSettings.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <chrono>
+#include <config/Configuration.hpp>
+#include <peripherals/api/IValve.hpp>
+#include <peripherals/valve/ValveControlStrategy.hpp>
 
 #include <ArduinoJson.h>
 
-#include <config/Configuration.hpp>
-
-#include <peripherals/api/IValve.hpp>
-#include <peripherals/valve/ValveControlStrategy.hpp>
+#include <chrono>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/peripherals/test/BitbangI2CTest.cpp
+++ b/components/peripherals/test/BitbangI2CTest.cpp
@@ -1,10 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_exception.hpp>
+#include <peripherals/environment/BitbangI2C.hpp>
 
 #include <deque>
 #include <vector>
-
-#include <peripherals/environment/BitbangI2C.hpp>
 
 using namespace cornucopia::ugly_duckling::peripherals::environment;
 

--- a/components/scheduling/src/scheduling/CompositeScheduler.hpp
+++ b/components/scheduling/src/scheduling/CompositeScheduler.hpp
@@ -1,9 +1,9 @@
 #pragma once
-
 #include "IScheduler.hpp"
 #include <utils/Chrono.hpp>
 
 #include <concepts>
+#include <memory>
 #include <vector>
 
 namespace cornucopia::ugly_duckling::utils::scheduling {

--- a/components/scheduling/src/scheduling/CompositeScheduler.hpp
+++ b/components/scheduling/src/scheduling/CompositeScheduler.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <concepts>
-#include <vector>
-
+#include "IScheduler.hpp"
 #include <utils/Chrono.hpp>
 
-#include "IScheduler.hpp"
+#include <concepts>
+#include <vector>
 
 namespace cornucopia::ugly_duckling::utils::scheduling {
 

--- a/components/scheduling/src/scheduling/DelayScheduler.hpp
+++ b/components/scheduling/src/scheduling/DelayScheduler.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <chrono>
-#include <optional>
-
+#include "IScheduler.hpp"
 #include <utils/Chrono.hpp>
 
-#include "IScheduler.hpp"
+#include <chrono>
+#include <optional>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/scheduling/src/scheduling/DelayScheduler.hpp
+++ b/components/scheduling/src/scheduling/DelayScheduler.hpp
@@ -4,6 +4,7 @@
 #include <utils/Chrono.hpp>
 
 #include <chrono>
+#include <memory>
 #include <optional>
 
 using namespace std::chrono;

--- a/components/scheduling/src/scheduling/IScheduler.hpp
+++ b/components/scheduling/src/scheduling/IScheduler.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <chrono>
-#include <optional>
-#include <time.h>
+#include <peripherals/api/TargetState.hpp>
 
 #include <ArduinoJson.h>
+#include <time.h>
 
-#include <peripherals/api/TargetState.hpp>
+#include <chrono>
+#include <optional>
 
 namespace cornucopia::ugly_duckling::utils::scheduling {
 
@@ -69,7 +69,8 @@ struct Converter<system_clock::time_point> {
         // Windows doesn't have strptime, use sscanf to parse ISO 8601
         int year, month, day, hour, min, sec;
         if (sscanf(src.as<const char*>(), "%d-%d-%dT%d:%d:%dZ",
-                   &year, &month, &day, &hour, &min, &sec) == 6) {
+                &year, &month, &day, &hour, &min, &sec)
+            == 6) {
             tm.tm_year = year - 1900;
             tm.tm_mon = month - 1;
             tm.tm_mday = day;

--- a/components/scheduling/src/scheduling/IScheduler.hpp
+++ b/components/scheduling/src/scheduling/IScheduler.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Log.hpp>
 #include <peripherals/api/TargetState.hpp>
 
 #include <ArduinoJson.h>

--- a/components/scheduling/src/scheduling/LightSensorScheduler.hpp
+++ b/components/scheduling/src/scheduling/LightSensorScheduler.hpp
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <chrono>
-#include <optional>
-
+#include "IScheduler.hpp"
+#include <peripherals/api/ILightSensor.hpp>
 #include <utils/Chrono.hpp>
 
-#include <peripherals/api/ILightSensor.hpp>
-
-#include "IScheduler.hpp"
+#include <chrono>
+#include <optional>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/scheduling/src/scheduling/LightSensorScheduler.hpp
+++ b/components/scheduling/src/scheduling/LightSensorScheduler.hpp
@@ -1,10 +1,10 @@
 #pragma once
-
 #include "IScheduler.hpp"
 #include <peripherals/api/ILightSensor.hpp>
 #include <utils/Chrono.hpp>
 
 #include <chrono>
+#include <memory>
 #include <optional>
 
 using namespace std::chrono;

--- a/components/scheduling/src/scheduling/MoistureBasedScheduler.hpp
+++ b/components/scheduling/src/scheduling/MoistureBasedScheduler.hpp
@@ -9,6 +9,7 @@
 #include <concepts>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string_view>

--- a/components/scheduling/src/scheduling/MoistureBasedScheduler.hpp
+++ b/components/scheduling/src/scheduling/MoistureBasedScheduler.hpp
@@ -1,4 +1,8 @@
 #pragma once
+#include <peripherals/api/IFlowMeter.hpp>
+#include <peripherals/api/ISoilMoistureSensor.hpp>
+#include <scheduling/IScheduler.hpp>
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -9,11 +13,6 @@
 #include <stdexcept>
 #include <string_view>
 #include <utility>
-
-#include <peripherals/api/IFlowMeter.hpp>
-#include <peripherals/api/ISoilMoistureSensor.hpp>
-
-#include <scheduling/IScheduler.hpp>
 
 using namespace std::chrono_literals;
 using namespace cornucopia::ugly_duckling::peripherals::api;

--- a/components/scheduling/src/scheduling/OverrideScheduler.hpp
+++ b/components/scheduling/src/scheduling/OverrideScheduler.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <scheduling/IScheduler.hpp>
+
 #include <chrono>
 #include <optional>
 #include <string>
-
-#include <scheduling/IScheduler.hpp>
 
 namespace cornucopia::ugly_duckling::utils::scheduling {
 

--- a/components/scheduling/src/scheduling/TimeBasedScheduler.hpp
+++ b/components/scheduling/src/scheduling/TimeBasedScheduler.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <scheduling/IScheduler.hpp>
+#include <utils/Chrono.hpp>
+
 #include <algorithm>
 #include <chrono>
 #include <optional>
 #include <vector>
-
-#include <scheduling/IScheduler.hpp>
-#include <utils/Chrono.hpp>
 
 namespace cornucopia::ugly_duckling::utils::scheduling {
 

--- a/components/scheduling/test/scheduling/DelaySchedulerTest.cpp
+++ b/components/scheduling/test/scheduling/DelaySchedulerTest.cpp
@@ -1,15 +1,12 @@
-#include <catch2/catch_test_macros.hpp>
-
 #include "TestHelpers.hpp"
-
-#include <chrono>
-#include <memory>
-
 #include <FakeLog.hpp>
-
+#include <catch2/catch_test_macros.hpp>
 #include <peripherals/api/TargetState.hpp>
 #include <scheduling/DelayScheduler.hpp>
 #include <scheduling/IScheduler.hpp>
+
+#include <chrono>
+#include <memory>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;
@@ -239,7 +236,7 @@ TEST_CASE("DelayScheduler: different delays for open and close") {
 
     // Request close - should take 8s
     mockScheduler->setTarget(TargetState::Closed);
-    REQUIRE(delayScheduler.tick(T1) == ScheduleResult { .targetState = TargetState::Open, .nextDeadline = 8s });    // Stay open
-    REQUIRE(delayScheduler.tick(T1 + 5s) == ScheduleResult { .targetState = TargetState::Open, .nextDeadline = 3s });    // Still open after 5s
+    REQUIRE(delayScheduler.tick(T1) == ScheduleResult { .targetState = TargetState::Open, .nextDeadline = 8s });                       // Stay open
+    REQUIRE(delayScheduler.tick(T1 + 5s) == ScheduleResult { .targetState = TargetState::Open, .nextDeadline = 3s });                  // Still open after 5s
     REQUIRE(delayScheduler.tick(T1 + 8s) == ScheduleResult { .targetState = TargetState::Closed, .shouldPublishTelemetry = true });    // Now closed
 }

--- a/components/scheduling/test/scheduling/Fakes.hpp
+++ b/components/scheduling/test/scheduling/Fakes.hpp
@@ -1,13 +1,12 @@
 // fakes.hpp
 #pragma once
 
-#include <cmath>
-#include <deque>
-
 #include <peripherals/api/IFlowMeter.hpp>
 #include <peripherals/api/ISoilMoistureSensor.hpp>
-
 #include <scheduling/MoistureBasedScheduler.hpp>
+
+#include <cmath>
+#include <deque>
 
 using namespace cornucopia::ugly_duckling::peripherals::api;
 

--- a/components/scheduling/test/scheduling/Fakes.hpp
+++ b/components/scheduling/test/scheduling/Fakes.hpp
@@ -1,12 +1,12 @@
 // fakes.hpp
 #pragma once
-
 #include <peripherals/api/IFlowMeter.hpp>
 #include <peripherals/api/ISoilMoistureSensor.hpp>
 #include <scheduling/MoistureBasedScheduler.hpp>
 
 #include <cmath>
 #include <deque>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::peripherals::api;
 

--- a/components/scheduling/test/scheduling/LightSensorSchedulerTest.cpp
+++ b/components/scheduling/test/scheduling/LightSensorSchedulerTest.cpp
@@ -1,15 +1,12 @@
-#include <catch2/catch_test_macros.hpp>
-
 #include "TestHelpers.hpp"
-
-#include <chrono>
-#include <memory>
-
 #include <FakeLog.hpp>
-
+#include <catch2/catch_test_macros.hpp>
 #include <peripherals/api/ILightSensor.hpp>
 #include <peripherals/api/TargetState.hpp>
 #include <scheduling/LightSensorScheduler.hpp>
+
+#include <chrono>
+#include <memory>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/scheduling/test/scheduling/MoistureBasedSchedulerTest.cpp
+++ b/components/scheduling/test/scheduling/MoistureBasedSchedulerTest.cpp
@@ -1,14 +1,10 @@
-#include <functional>
-
-#include <catch2/catch_test_macros.hpp>
-
-#include <FakeLog.hpp>
-
-#include <scheduling/MoistureBasedScheduler.hpp>
-
 #include "Fakes.hpp"
-
+#include <FakeLog.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <scheduling/MoistureBasedScheduler.hpp>
 #include <utils/Chrono.hpp>
+
+#include <functional>
 
 namespace cornucopia::ugly_duckling::utils::scheduling {
 

--- a/components/scheduling/test/scheduling/MoistureKalmanFilterTest.cpp
+++ b/components/scheduling/test/scheduling/MoistureKalmanFilterTest.cpp
@@ -1,12 +1,10 @@
+#include <FakeLog.hpp>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <scheduling/MoistureKalmanFilter.hpp>
 
 #include <cmath>
 #include <random>
-
-#include <scheduling/MoistureKalmanFilter.hpp>
-
-#include <FakeLog.hpp>
 
 using Catch::Approx;
 

--- a/components/scheduling/test/scheduling/TestHelpers.hpp
+++ b/components/scheduling/test/scheduling/TestHelpers.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <string>
+#include <FakeLog.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <scheduling/IScheduler.hpp>
+
 #include <iostream>
 #include <sstream>
-
-#include <catch2/catch_test_macros.hpp>
-
-#include <FakeLog.hpp>
-
-#include <scheduling/IScheduler.hpp>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::utils::scheduling;
 

--- a/components/scheduling/test/scheduling/TimeBasedSchedulerTest.cpp
+++ b/components/scheduling/test/scheduling/TimeBasedSchedulerTest.cpp
@@ -1,15 +1,14 @@
-#include <catch2/catch_test_macros.hpp>
-
 #include "TestHelpers.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <peripherals/api/IValve.hpp>
+#include <scheduling/TimeBasedScheduler.hpp>
+
+#include <time.h>
 
 #include <chrono>
 #include <cstdio>
 #include <ctime>
 #include <iomanip>
-#include <time.h>
-
-#include <peripherals/api/IValve.hpp>
-#include <scheduling/TimeBasedScheduler.hpp>
 
 using namespace std::chrono;
 using namespace std::chrono_literals;

--- a/components/test-support/src/Log.hpp
+++ b/components/test-support/src/Log.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+// In unit tests, shadow kernel's Log.hpp with the fake implementation
+// so that headers using LOGGING_TAG() can be included without ESP-IDF.
+#include <FakeLog.hpp>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2,11 +2,11 @@
 #include <cstdio>
 #endif
 
-#include <esp_log.h>
-
 #include <Device.hpp>
 #include <HardwareVersion.hpp>
 #include <MacAddress.hpp>
+
+#include <esp_log.h>
 
 #if defined(CONFIG_IDF_TARGET_ESP32S3)
 

--- a/test/embedded-tests/components/kernel-test/src/ConfigStagingTest.cpp
+++ b/test/embedded-tests/components/kernel-test/src/ConfigStagingTest.cpp
@@ -1,17 +1,16 @@
 #include <catch2/catch_test_macros.hpp>
-
-#include <memory>
-#include <string>
-#include <unordered_map>
-
-#include <nvs_flash.h>
-
 #include <config/ConfigBootPlan.hpp>
 #include <config/ConfigEnvelope.hpp>
 #include <config/ConfigStaging.hpp>
 #include <config/ConfigState.hpp>
 #include <config/ConfigStateStore.hpp>
 #include <config/StoredConfig.hpp>
+
+#include <nvs_flash.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::config;

--- a/test/embedded-tests/components/kernel-test/src/ConfigStateStoreTest.cpp
+++ b/test/embedded-tests/components/kernel-test/src/ConfigStateStoreTest.cpp
@@ -1,12 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
-
-#include <memory>
-
-#include <nvs_flash.h>
-
 #include <config/ConfigBootPlan.hpp>
 #include <config/ConfigState.hpp>
 #include <config/ConfigStateStore.hpp>
+
+#include <nvs_flash.h>
+
+#include <memory>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::config;

--- a/test/embedded-tests/components/kernel-test/src/FirmwareRollbackTest.cpp
+++ b/test/embedded-tests/components/kernel-test/src/FirmwareRollbackTest.cpp
@@ -1,6 +1,5 @@
+#include <FirmwareRollback.hpp>
 #include <catch2/catch_test_macros.hpp>
-
-#include <cstring>
 
 #include <esp_app_desc.h>
 #include <esp_app_format.h>
@@ -9,7 +8,7 @@
 #include <esp_partition.h>
 #include <esp_rom_crc.h>
 
-#include <FirmwareRollback.hpp>
+#include <cstring>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/test/embedded-tests/components/kernel-test/src/StoredConfigTest.cpp
+++ b/test/embedded-tests/components/kernel-test/src/StoredConfigTest.cpp
@@ -1,12 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
-
-#include <memory>
-#include <string>
+#include <config/ConfigEnvelope.hpp>
+#include <config/StoredConfig.hpp>
 
 #include <nvs_flash.h>
 
-#include <config/ConfigEnvelope.hpp>
-#include <config/StoredConfig.hpp>
+#include <memory>
+#include <string>
 
 using namespace cornucopia::ugly_duckling::kernel;
 using namespace cornucopia::ugly_duckling::kernel::config;

--- a/test/embedded-tests/components/kernel-test/src/WatchdogTest.cpp
+++ b/test/embedded-tests/components/kernel-test/src/WatchdogTest.cpp
@@ -1,10 +1,9 @@
+#include <Watchdog.hpp>
 #include <catch2/catch_test_macros.hpp>
-
-#include <optional>
 
 #include <freertos/FreeRTOS.h>
 
-#include <Watchdog.hpp>
+#include <optional>
 
 using namespace cornucopia::ugly_duckling::kernel;
 

--- a/test/embedded-tests/main/test_main.cpp
+++ b/test/embedded-tests/main/test_main.cpp
@@ -1,14 +1,14 @@
-#include <iomanip>
-#include <iostream>
-#include <stdio.h>
-#include <string_view>
-
-#include <esp_ota_ops.h>
-
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_case_info.hpp>
 #include <catch2/reporters/catch_reporter_event_listener.hpp>
 #include <catch2/reporters/catch_reporter_registrars.hpp>
+
+#include <esp_ota_ops.h>
+#include <stdio.h>
+
+#include <iomanip>
+#include <iostream>
+#include <string_view>
 
 inline std::string_view filenameFromPath(const char* path) {
     if (!path) {

--- a/test/unit-tests/CMakeLists.txt
+++ b/test/unit-tests/CMakeLists.txt
@@ -34,6 +34,9 @@ FetchContent_MakeAvailable(ArduinoJson)
 set(COMPONENTS_DIR ${CMAKE_SOURCE_DIR}/../../components)
 
 include_directories(
+    # test-support first: its Log.hpp shim shadows kernel's real Log.hpp
+    # so that headers using LOGGING_TAG() compile without ESP-IDF
+    ${COMPONENTS_DIR}/test-support/src
     ${COMPONENTS_DIR}/functions/src
     ${COMPONENTS_DIR}/functions/test
     ${COMPONENTS_DIR}/kernel/src
@@ -44,7 +47,6 @@ include_directories(
     ${COMPONENTS_DIR}/scheduling/src
     ${COMPONENTS_DIR}/scheduling/test
     ${COMPONENTS_DIR}/utils/src
-    ${COMPONENTS_DIR}/test-support/src
 )
 
 # Collect all test source files

--- a/test/unit-tests/main/test_main.cpp
+++ b/test/unit-tests/main/test_main.cpp
@@ -1,12 +1,13 @@
-#include <iomanip>
-#include <iostream>
-#include <stdio.h>
-#include <string_view>
-
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_case_info.hpp>
 #include <catch2/reporters/catch_reporter_event_listener.hpp>
 #include <catch2/reporters/catch_reporter_registrars.hpp>
+
+#include <stdio.h>
+
+#include <iomanip>
+#include <iostream>
+#include <string_view>
 
 inline std::string_view filenameFromPath(const char* path) {
     if (!path) {
@@ -42,14 +43,14 @@ CATCH_REGISTER_LISTENER(testRunListener)
 int main(int argc, char* argv[]) {
     Catch::Session session;
     session.configData().rngSeed = 12345;
-    
+
     int result = session.run(argc, argv);
-    
+
     if (result != 0) {
         printf("Test failed with result %d\n", result);
     } else {
         printf("Test passed.\n");
     }
-    
+
     return result;
 }

--- a/tools/activate_idf.sh
+++ b/tools/activate_idf.sh
@@ -33,3 +33,6 @@ case ":${PATH}:" in
     *":${IDF_PATH}/tools:"*) ;;
     *) export PATH="${IDF_PATH}/tools:${PATH}" ;;
 esac
+
+# Use project-local Git hooks (.githooks/) for clang-format pre-commit etc.
+git config core.hooksPath .githooks 2>/dev/null

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Runs the ESP-IDF clang-format.
+# Used by VS Code (C_Cpp.clang_format_path) and pre-commit hooks
+# to ensure everyone uses the same version as CI.
+
+CF="$(command -v clang-format 2>/dev/null)"
+
+if [ -z "$CF" ]; then
+    # VS Code doesn't source activate_idf.sh, so clang-format won't be on
+    # PATH. Fall back to the conventional ESP-IDF tools location.
+    # shellcheck disable=SC2012
+    CF="$(ls -1d "$HOME"/.espressif/tools/esp-clang/*/esp-clang/bin/clang-format 2>/dev/null | sort -V | tail -1)"
+fi
+
+if [ -z "$CF" ]; then
+    echo "Error: clang-format not found. Source tools/activate_idf.sh or install ESP-IDF tools." >&2
+    exit 1
+fi
+
+exec "$CF" "$@"


### PR DESCRIPTION
Add SortIncludes, IncludeBlocks: Regroup, and IncludeCategories to
enforce project-first ordering: .hpp (project) → .h (ESP-IDF/third-party)
→ extensionless (C++ stdlib), separated by blank lines.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWLxSEszYBH2VRkervWT5c